### PR TITLE
Dev-new-fixes-2

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -126,6 +126,24 @@ Test Mode (dry run):
 
 > Test Mode will <strong>Not</strong> run mover but will output the custom find command results to <em>/tmp/ca.mover.tuning/</em>. Caution - If you have "Move Now button follows plug-in filters" set to <strong>No</strong>, original Mover will still run.
 
+Validate input filenames to prevent attacks
+: <select name='validate_filenames' size='1' class='narrow'>
+<?=mk_option($cfg['validate_filenames'],"yes","Yes")?>
+<?=mk_option($cfg['validate_filenames'],"no",'No')?>
+</select>
+<strong>No</strong> <em>- setting effectively disables validation of input filenames</em>
+
+<blockquote class="inline_help">
+<p> <em>In cybersecurity, filenames can be a critical vector for potential attacks and system vulnerabilities. Unsanitized filenames pose significant risks that can compromise system integrity and security.</em></p>
+<p> Validate input filenames will check every filename before it is processed by the Mover. This ensures that <strong>only valid</strong> filenames are accepted, <strong>reducing the risk</strong> of attacks and vulnerabilities.</p>
+<p> Disable <strong>Only</strong> if you have many files to move and you are <strong>sure</strong> that all filenames are <strong>valid</strong> and do not contain any potential security risks.</p>
+<p> 1. <strong>Check filename length</strong> - If the filename exceeds 255 characters, it will be rejected.</p>
+<p> 2. <strong>Check for invalid characters</strong> - The filename should not contain any characters that are considered invalid for filenames, such as 
+(<strong><em> $ </em></strong>), (<strong><em> / </em></strong>), (<strong><em> < </em></strong>), (<strong><em> > </em></strong>), (<strong><em> : </em></strong>), (<strong><em> " </em></strong>), (<strong><em> \ </em></strong>), (<strong><em> ? </em></strong>), (<strong><em> * </em></strong>).</p>
+<p> 3. <strong>Prevent path traversal</strong> - The filename should not contain any characters that can be used to traverse directories, such as (<strong><em> ../ </em></strong>).</p>
+<p> If one of these checks fails, the filename will be rejected.</p>
+</blockquote>
+
 Log Mover Tuning plugin actions
 : <select name='logging' size='1' class='narrow'>
 <?=mk_option($cfg['logging'],"no",'No')?>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -127,9 +127,9 @@ Test Mode (dry run):
 > Test Mode will <strong>Not</strong> run mover but will output the custom find command results to <em>/tmp/ca.mover.tuning/</em>. Caution - If you have "Move Now button follows plug-in filters" set to <strong>No</strong>, original Mover will still run.
 
 Validate input filenames to prevent attacks
-: <select name='validate_filenames' size='1' class='narrow'>
-<?=mk_option($cfg['validate_filenames'],"yes","Yes")?>
-<?=mk_option($cfg['validate_filenames'],"no",'No')?>
+: <select name='validateFilenames' size='1' class='narrow'>
+<?=mk_option($cfg['validateFilenames'],"yes","Yes")?>
+<?=mk_option($cfg['validateFilenames'],"no",'No')?>
 </select>
 <strong>No</strong> <em>- setting effectively disables validation of input filenames</em>
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -499,14 +499,14 @@ getMoverSettings() {
         mvlogger "Debug Logging: $(cfg debuglogging)"
     fi
 
-    if [ -z $(cfg validate_filenames) ]; then
+    if [ -z $(cfg validateFilenames) ]; then
         if [[ ! "$config_file" =~ shareOverrideConfig ]]; then
             mvlogger "No Validate Filenames argument provided, defaulting to yes"
-            echo 'validate_filenames="yes"' >>$config_file
+            echo 'validateFilenames="yes"' >>$config_file
             VALIDATE_FILENAMES="yes"
         fi
     else
-        VALIDATE_FILENAMES=$(cfg validate_filenames)
+        VALIDATE_FILENAMES=$(cfg validateFilenames)
         mvlogger "Validate Filenames: $VALIDATE_FILENAMES"
     fi
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -496,7 +496,7 @@ getMoverSettings() {
         else
             DEBUGLEVEL=1
         fi
-        mvlogger "Debug Logging: $DEBUGLEVEL"
+        mvlogger "Debug Logging: $debuglogging"
     fi
 }
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -603,6 +603,12 @@ createFilteredFilelist() {
             fi
         fi
 
+        # If primary storage share set to cache prefer then set $MOVINGPCTTHRESHOLD and $FREEINGPCTLIMIT to 95% to avoid moving from cache share bellow 95% threshold.
+        if [ "$SHAREUSECACHE" = "prefer" ] && [ "$SECONDARYSTORAGENAME" = "user0" ]; then
+            MOVINGPCTTHRESHOLD=99
+            FREEINGPCTLIMIT=0
+        fi
+
         #Find the current percent of used size of pool.
         if is_zfs_mountpoint_fstype "/mnt/$PRIMARYSTORAGENAME"; then
             #mvlogger "$PRIMARYSTORAGENAME is zfs."
@@ -666,6 +672,10 @@ createFilteredFilelist() {
 
         # Give information according to cache mode and thresholds
         if [ "$SHAREUSECACHE" = "prefer" ]; then
+            # If primary share cache preferred, check if it is used and pool usage is high, set 98% free threshold
+            if [ "$SECONDARYSTORAGENAME" = "user0" ] && [ "$POOLPCTUSED" -eq 100 ]; then
+                FREEINGPCTLIMIT=98
+            fi
             mvlogger "Moving threshold: $MOVINGPCTTHRESHOLD% ($(bytes_to_human $MOVESIZETHRESH)) ; Freeing threshold: $FREEINGPCTLIMIT% ($(bytes_to_human $PRIMARYSIZETHRESH))"
             if [ "$REBALANCESHARES" = "yes" ] && [ -n "$UNATTENDEDSTORAGE" ]; then
                 mvlogger "Mover action: $SECONDARYSTORAGENAME->$PRIMARYSTORAGENAME (cache:prefer). Rebalance shares option is selected"
@@ -1042,6 +1052,8 @@ decideMoveActions() {
             if (storage_pool == $1) {
                 # Make decision to move or keep:
                 action = (($4 != "only" && $4 != "skipped") && (($4 == "prefer" || $4 == "yes") && (pool_sums[$1] >= $6 && AGE == -1) || AGE >= 0) || $4 == "no" ) ? "move from primary" : "keep on primary"
+                #action = (($4 != "only" && $4 != "skipped" && $4 != "prefer") && (($4 == "yes") && (pool_sums[$1] >= $6 && AGE == -1) || AGE >= 0) || $4 == "no" ) ? "move from primary" : "keep on primary"
+
 
                 if (action == "keep on primary")  {
                     source = storage_path

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1508,7 +1508,7 @@ start() {
     done
 
     mvlogger "$(titleLine 'WE ARE DONE !' '*')"
-    unraid_notify "All files were successfully moved by Mover Tuning plugin." "success"
+    unraid_notify "A total of $TOTALFILES files representing $(bytes_to_human $TOTALSIZE) were successfully moved/synced by Mover Tuning plugin." "success"
     [ $LOGLEVEL = 0 ] && echo "Mover tuning plugin done!"
 }
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -498,6 +498,18 @@ getMoverSettings() {
         fi
         mvlogger "Debug Logging: $(cfg debuglogging)"
     fi
+
+    if [ -z $(cfg validate_filenames) ]; then
+        if [[ ! "$config_file" =~ shareOverrideConfig ]]; then
+            mvlogger "No Validate Filenames argument provided, defaulting to yes"
+            echo 'validate_filenames="yes"' >>$config_file
+            VALIDATE_FILENAMES="yes"
+        fi
+    else
+        VALIDATE_FILENAMES=$(cfg validate_filenames)
+        mvlogger "Validate Filenames: $VALIDATE_FILENAMES"
+    fi
+
 }
 
 resetRunOnceMoverSettings() {
@@ -1258,11 +1270,13 @@ processTheMoves() {
             #mvDebuglogger "FILEPATH= $FILEPATH" "FILEPATH"
 
             # Check File by validate function and skip if error
-            if ! validate_filename "$(basename "$FILEPATH")"; then
-                mvlogger "Error: Invalid filename path: '$FILEPATH'"
-                continue
-            #else
-            #    mvlogger "Valid filename"
+            if [ $VALIDATE_FILENAMES = "yes" ]; then
+                if ! validate_filename "$(basename "$FILEPATH")"; then
+                    mvlogger "Error: Invalid filename path: '$FILEPATH'"
+                    continue
+                #else
+                #    mvlogger "Valid filename"
+                fi
             fi
 
             # Get files to rsync:

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -496,7 +496,7 @@ getMoverSettings() {
         else
             DEBUGLEVEL=1
         fi
-        mvlogger "Debug Logging: $debuglogging"
+        mvlogger "Debug Logging: $(cfg debuglogging)"
     fi
 }
 


### PR DESCRIPTION
- Added option for users can enable/disable Validation (Sanitize) check for input filenames to prevent attacks future added befor.
- Fixed Debug = yes/no instead of 0/1 in mover logs.
- Fixed primary cache prefer not to move data. Set fixed moving threshold to 99% freeing threshold to 0% for skip moving.
  when chache is full set freeing to 98% to move some data. Maybe better fix will be later.

Fixes #20