### PR TITLE
Fix:  filelist path containing whitespace fails

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -447,6 +447,11 @@ getMoverSettings() {
     else
         if [ $(cfg filelistf) = "yes" ]; then
             SKIPFILESLIST=$(cfg filelistv)
+            if grep -q '^[[:space:]]\|[[:space:]]$' <<< "$SKIPFILESLIST"; then
+                TRIMMED_SKIPFILESLIST=$(sed 's/^[[:space:]]\+\|[[:space:]]\+$//g' <<< "$SKIPFILESLIST")
+                sed -i "s|filelistv=\"$SKIPFILESLIST\"|filelistv=\"$TRIMMED_SKIPFILESLIST\"|g" "$config_file"
+                SKIPFILESLIST=$TRIMMED_SKIPFILESLIST
+            fi
             mvlogger "Skip file list: $SKIPFILESLIST"
         else
             [[ ! "$config_file" =~ shareOverrideConfig ]] && SKIPFILESLIST=""


### PR DESCRIPTION
Mover.tuning.page: Implement trim for filelist input

Fixes #121 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced whitespace trimming for the skip files list to prevent processing errors when users enter data with leading or trailing spaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->