### PR TITLE
Add wildcard file extension support (recursively) to file list exclusion

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -833,8 +833,9 @@ _(File list path)_:
 <blockquote class="inline_help">
 <p> Full path to a file that contains a list of files and folder you want ignored from being moved off the Primary (cache) pool.</p>
 <p> File List example: <strong><em>/mnt/user/Files/mover_ignore.txt</em></strong> , The contents of this file should be one entry per line.</p>
-<p> Folder example: <strong><em>/mnt/cache_ssd/Files/MyFiles</em></strong> , Do <strong>NOT</strong> put (<strong><em> * </em></strong>) or (<strong><em> / </em></strong>) at the end of the line.</p>
+<p> Folder example: <strong><em>/mnt/cache_ssd/Files/MyFiles</em></strong> , Do <strong>NOT</strong> put "<strong><em> * </em></strong>" (except for wildcard file extensions) or "<strong><em> / </em></strong>" at the end of the line.</p>
 <p> File example: <strong><em>/mnt/cache_ssd/Files/MyFile.txt</em></strong> .</p>
+<p> Wildcard example: <strong><em>/mnt/cache_ssd/Files/MyFolder/*.ext</em></strong> , excludes all files matching the pattern recursively within that folder. Size is not tracked for wildcard entries.</p>
 </blockquote>
 
 _(Ignore file types)_:

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1186,6 +1186,17 @@ createFilteredFilelist() {
                 skipped_path="${skipped_path%"${skipped_path##*[!/*]}"}"
                 #skipped_path="${skipped_path%/}" # Remove potential trailing slash
                 mvDebuglogger "skipped_path = $skipped_path" "Skipped Path"
+
+                # Check if the last path component contains a wildcard pattern
+                lastcomponent="${skipped_path##*/}"
+                if [[ "$lastcomponent" == *"*"* ]]; then
+                    mvDebuglogger "${skipped_path} - is a wildcard pattern" "Skipped Path"
+                    mvlogger "Skipping wildcard pattern: ${skipped_path} (size not tracked)"
+                    FINDSTR="$FINDSTR -not -path \"${skipped_path//[/\\[}\"" # fixed when folder contain '['
+                    echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|0|0|0|0|${skipped_path}|f" >>"$FILTERED_FILELIST"
+                    continue
+                fi
+
                 if [[ -d "${skipped_path}" || -f "${skipped_path}" ]]; then
                     mvDebuglogger "${skipped_path} - exists" "Skipped Path"
                     SKIPPED_PATH_RESERVED_SPACE="$(du -sh "${skipped_path}" | awk '{print $1}' | human_to_bytes)"


### PR DESCRIPTION
This PR adds code to allow a user to set a path with a wildcard extension (*.ext) in the file list path file that is configured by the user which allows the mover to ignore all files with a specified file extension from being processed when the mover runs. This is done recusively, so for the example "/mnt/cache_ssd/Files/MyFolder/*.ext" all files withing MyFolder/ (and all subfolders) that have the .ext extension are ignored by the mover. Therefore also updated the description of the file list path.


My main intention was my jellyfin instance. Jellyfin is configured to save the .nfo files next to the media files (and i would like to move the images to the same location aswell). Without this PR the nfo (and image) files are moved to the array which results in the whole (or parts of the) array spinning up when i browse my jellyfin library. Using this pr should avoid this by allowing the user to exclude those files from moving leaving them on the primary storage while the media files will move to secondary.

But while this was intended for jellyfin and to prevent disk spinup, it should also help with plex or emby form that matter.

This will add lines like this to the mover_tuning_xyz.log file:
```
17:50:03.285 Skipping wildcard pattern: /mnt/cache/data/media/*.nfo (size not tracked)
17:50:03.287 Skipping wildcard pattern: /mnt/cache/data/media/*.png (size not tracked)
17:50:03.289 Skipping wildcard pattern: /mnt/cache/data/media/*.jpg (size not tracked)
```
and the mover_action_xyz.log:
```
cache|data|skipped|9999999999|0|1941076705280|800159154176|0|0|keep on primary|/mnt/cache|none|data/media/*.jpg|f
cache|data|skipped|9999999999|0|1941076705280|800159154176|0|0|keep on primary|/mnt/cache|none|data/media/*.nfo|f
cache|data|skipped|9999999999|0|1941076705280|800159154176|0|0|keep on primary|/mnt/cache|none|data/media/*.png|f
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified help text for the "Ignore file types" feature with wildcard pattern examples and formatting guidelines.

* **Bug Fixes**
  * Improved handling of wildcard patterns in ignored file entries; wildcards now exclude matching files recursively without size tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->