### PR TITLE
Fix: filename-driven shell injection / data loss in rsync move path

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1858,11 +1858,11 @@ processTheMoves() {
                 fi
             fi
 
-            #Prepare RSYNC_CMD
-            RSYNC_CMD="rsync --archive --xattrs --relative --hard-links"
+            #Prepare RSYNC_CMD as an array so it is never re-parsed by the shell
+            RSYNC_CMD=(rsync --archive --xattrs --relative --hard-links)
 
             if [ "$TESTMODE" = "yes" ]; then
-                RSYNC_CMD+=" --dry-run"
+                RSYNC_CMD+=(--dry-run)
             fi
 
             # print to debug $SYNCED_FILES $FILEPATH
@@ -1883,6 +1883,12 @@ processTheMoves() {
             SYNCED_FILES=$(grep "|$NBLINKS|$INODE|" "$MOVER_ACTIONLIST" | grep "|$MODIFICATIONTIME|" | grep "ary|$SOURCE|" | cut -d'|' -f13 | while read line; do echo "\"$SOURCE/./$line\""; done | tr '\n' ' ')
             GUI_CURRENT_FILE=$SYNCED_FILES
 
+            # Same file list as a real array for the rsync call below. SYNCED_FILES
+            # above is kept as a display/count string only; passing the filenames to
+            # rsync via this array (instead of eval) stops the shell from interpreting
+            # spaces, backticks, $(...), redirections, etc. that appear in file names.
+            mapfile -t SYNCED_FILES_ARR < <(grep "|$NBLINKS|$INODE|" "$MOVER_ACTIONLIST" | grep "|$MODIFICATIONTIME|" | grep "ary|$SOURCE|" | cut -d'|' -f13 | while IFS= read -r line; do printf '%s\n' "$SOURCE/./$line"; done)
+
             # Check if list is complete
             NBFILES=$(($(echo "$SYNCED_FILES" | grep -o '" "' | wc -l) + 1))
             if [ -f "${SOURCE}/${FILEPATH}" ] && [ $NBFILES != "$NBLINKS" ]; then
@@ -1897,7 +1903,7 @@ processTheMoves() {
                 mvlogger "Moving $SYNCED_FILES to  $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
                 rsync_action="Move"
                 # Finalize RSYNC_CMD
-                RSYNC_CMD+=" --remove-source-files"
+                RSYNC_CMD+=(--remove-source-files)
             elif [[ "$ACTION" =~ "sync" ]]; then
                 # Some verbosity
                 GUI_ACTION="Synchronizing to $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
@@ -1927,9 +1933,9 @@ processTheMoves() {
                 if [ "$TESTMODE" = "yes" ]; then
                     mvlogger "TEST MODE: Would $rsync_action using rsync utility"
                 else
-                    mvDebuglogger "Rsync cmd: $RSYNC_CMD, $rsync_action $filetype: $SYNCED_FILES, Dest: $DESTINATION/" "$rsync_action Action"
+                    mvDebuglogger "Rsync cmd: ${RSYNC_CMD[*]}, $rsync_action $filetype: $SYNCED_FILES, Dest: $DESTINATION/" "$rsync_action Action"
                     # Perform rsync. relative paths and hardlinks
-                    eval "$RSYNC_CMD" "$SYNCED_FILES" "$DESTINATION/"
+                    "${RSYNC_CMD[@]}" "${SYNCED_FILES_ARR[@]}" "$DESTINATION/"
                 fi
             fi
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1936,7 +1936,11 @@ processTheMoves() {
                 else
                     mvDebuglogger "Rsync cmd: ${RSYNC_CMD[*]}, $rsync_action $filetype: $SYNCED_FILES, Dest: $DESTINATION/" "$rsync_action Action"
                     # Perform rsync. relative paths and hardlinks
-                    "${RSYNC_CMD[@]}" "${SYNCED_FILES_ARR[@]}" "$DESTINATION/"
+                    if [ ${#SYNCED_FILES_ARR[@]} -gt 0 ]; then
+                        "${RSYNC_CMD[@]}" "${SYNCED_FILES_ARR[@]}" "$DESTINATION/"
+                    else
+                        mvlogger "Error: No files found to move for $FILEPATH" "failure"
+                    fi
                 fi
             fi
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1942,8 +1942,12 @@ processTheMoves() {
 
             # Clean parent folder of files if empty
             if [[ "$ACTION" =~ "move" && "$FILETYPE" == "f" ]] && [[ "$CLEANFOLDERS" = "yes" || "$CLEANFOLDERS" = "topFolder" ]]; then
-                # Define a function to handle the directory cleanup logic
-                while IFS= read -r FILE; do
+                # Define a function to handle the directory cleanup logic.
+                # Iterate the array directly (was: echo "$SYNCED_FILES" | xargs),
+                # so filenames with quotes/spaces/special chars are handled safely.
+                for FILE in "${SYNCED_FILES_ARR[@]}"; do
+                    # Collapse the rsync --relative marker ("/./" -> "/")
+                    FILE="${FILE//\/.\//\/}"
                     DIR=$(dirname "$FILE")
                     mvDebuglogger "Current file: $FILE, Current folder: $DIR, Previous folder: $LAST_DIR, Previous count: $LAST_COUNT" "Clean Folder - Start Loop"
 
@@ -1988,7 +1992,7 @@ processTheMoves() {
                             fi
                         fi
                     fi
-                done <<<"$(echo "$SYNCED_FILES" | sed 's|/./|/|g' | xargs -n1 echo)"
+                done
             fi
 
             # Clean parent ZFS dataset if empty

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1879,18 +1879,19 @@ processTheMoves() {
                 fi
             fi
 
-            # Get files to rsync:
-            SYNCED_FILES=$(grep "|$NBLINKS|$INODE|" "$MOVER_ACTIONLIST" | grep "|$MODIFICATIONTIME|" | grep "ary|$SOURCE|" | cut -d'|' -f13 | while read line; do echo "\"$SOURCE/./$line\""; done | tr '\n' ' ')
-            GUI_CURRENT_FILE=$SYNCED_FILES
-
-            # Same file list as a real array for the rsync call below. SYNCED_FILES
-            # above is kept as a display/count string only; passing the filenames to
-            # rsync via this array (instead of eval) stops the shell from interpreting
+            # Get files to rsync as a real array. Passing the filenames to rsync
+            # via this array (instead of eval) stops the shell from interpreting
             # spaces, backticks, $(...), redirections, etc. that appear in file names.
             mapfile -t SYNCED_FILES_ARR < <(grep "|$NBLINKS|$INODE|" "$MOVER_ACTIONLIST" | grep "|$MODIFICATIONTIME|" | grep "ary|$SOURCE|" | cut -d'|' -f13 | while IFS= read -r line; do printf '%s\n' "$SOURCE/./$line"; done)
 
-            # Check if list is complete
-            NBFILES=$(($(echo "$SYNCED_FILES" | grep -o '" "' | wc -l) + 1))
+            # SYNCED_FILES is a display/count string only, derived from the array so
+            # the extraction pipeline above runs only once per file.
+            SYNCED_FILES=""
+            [[ ${#SYNCED_FILES_ARR[@]} -gt 0 ]] && printf -v SYNCED_FILES '"%s" ' "${SYNCED_FILES_ARR[@]}"
+            GUI_CURRENT_FILE=$SYNCED_FILES
+
+            # Check if list is complete (array length is exact, unlike parsing the string)
+            NBFILES=${#SYNCED_FILES_ARR[@]}
             if [ -f "${SOURCE}/${FILEPATH}" ] && [ $NBFILES != "$NBLINKS" ]; then
                 mvlogger "Expected $NBLINKS files, got $NBFILES. Not moving $SYNCED_FILES to prevent breaking hardlinks"
                 continue


### PR DESCRIPTION
To be upfront, this commit was done by claude fable after it helped me diagnose the problem.

The problem was: Today my unraid server´s webui was no longer accessible and was throwing "Internal server error 500".
There were some errors in the /var/log/phplog file with this content:
```
[19-Jul-2026 16:31:39 Europe/Berlin] PHP Fatal error:  Uncaught TypeError: extract(): Argument #1 ($array) must be of type array, false given in /usr/local/emhttp/plugins/dynamix/template.php:55
Stack trace:
#0 /usr/local/emhttp/plugins/dynamix/template.php(55): extract(false)
#1 {main}
  thrown in /usr/local/emhttp/plugins/dynamix/template.php on line 55
```
The template.php file at line 55 contains this code:
```
// Read network settings
extract(parse_ini_file('state/network.ini',true));
```
Those ini files are located at `/usr/local/emhttp/state` which itself is a symlink to `/var/local/emhttp`. The problem seems to be, that the mover tuning plugin had problems sanitizing some special filenames with special characters (mainly backticks and dollar signs, but also some others). For me mover tuning tried to move a file that contained dollar sign and the word "state" in it, which, due to the sanitizing bug, was interpreted as a filename itself and not part of the filename, which then resulted (together with --remove-source-files parameter) in the deletion of the symlinked folder `/usr/local/emhttp/state`.

---


I let Claude create a summary (in case my summary is not clear enough) of what the problem is, how to test it and how to fix it:
### Problem
processTheMoves() built the rsync command as a string and executed it with:
`eval "$RSYNC_CMD" "$SYNCED_FILES" "$DESTINATION/"`
eval re-parses its arguments through the shell, so any shell metacharacter contained in a file name is interpreted rather than treated as text.
Consequences, all triggered purely by what a file is named (mover runs as root):
- ` / $(...) in a name → arbitrary command execution as root
- $ → variable expansion silently rewrites the name ($100000 → 00000)
- embedded " / word-splitting → extra bare arguments handed to rsync --relative --remove-source-files, which then deletes unrelated relative paths

A real-world hit: a scheduled run deleted /usr/local/emhttp/state (the emhttp state symlink), taking down the entire Unraid webUI with extract(false) 500 errors in template.php, because a bare state token reached rsync from the working directory.

### Fix
  Stop routing filenames through eval:
  - RSYNC_CMD is now a bash array (options only — all safe tokens).
  - The file list is collected into a real array via mapfile and passed straight to rsync. The legacy SYNCED_FILES string is retained only for the existing display/count/cleanup code.
  - Call site becomes "${RSYNC_CMD[@]}" "${SYNCED_FILES_ARR[@]}" "$DESTINATION/".

How to test
```
base=$(mktemp -d); cd "$base"; mkdir realdir; ln -s realdir state
mkdir -p src/sub dst
for n in 'normal.jpg' 'price $100000.jpg' 'inject $(touch OWNED) x.jpg' 'quote" state ".jpg'; do : >"src/sub/$n"; done
```

#### OLD (vulnerable) pattern:
```
SF=$(for f in src/sub/*; do echo "\"$PWD/./$f\""; done | tr '\n' ' ')
RSYNC_CMD="rsync -a --relative --remove-source-files"; eval "$RSYNC_CMD" "$SF" dst/
ls OWNED 2>/dev/null && echo "RCE!"; [ -L state ] || echo "state DELETED!"
```

#### NEW (fixed) pattern — nothing executed, nothing deleted, all files moved:
```
mapfile -t A < <(for f in src/sub/*; do printf '%s\n' "$PWD/./$f"; done)
rsync -a --relative --remove-source-files "${A[@]}" dst/
```
The old block creates OWNED and removes the state symlink while dropping most files; the new block moves all four names with --relative structure intact and touches nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file move/sync operations to handle filenames with spaces and special characters more reliably.
  * Refined command execution to avoid unsafe re-parsing, and improved dry-run behavior consistency.
  * Kept existing behaviors for hardlink validation, archival handling, and optional source removal, while improving post-move cleanup of empty folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->