### PR TITLE
Detach the mover from the web request instead of using passthru()

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -41,7 +41,7 @@ function runMover($cmd)
 
     // Wait for the run to claim the pid file so the page's status poll does
     // not race a mover that has not started yet.
-    for ($i = 0; $i < 50 && !file_exists("/var/run/mover.pid"); $i++) {
+    for ($i = 0; $i < 50 && file_exists("/var/run/mover.pid") === false; $i++) {
         usleep(100000);
     }
 }

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -116,6 +116,20 @@ function startMover()
         logger("Cron + options: $options");
     }
 
+    // $options, moverNice and moverIO are the only values interpolated into the
+    // mover command line, and all three come from fixed sets: age_mover's own
+    // command list, and the two priority dropdowns on the settings page.
+    // Anything else is rejected rather than handed to a shell.
+    $allowedCommands = ["start", "stop", "softstop", "status", "reset", "debug"];
+    if (in_array($options, $allowedCommands, true) === false) {
+        logger("Refusing to run mover: unrecognised command '$options'");
+        exit();
+    }
+
+    $allowedIO = ["-c 2 -n 0", "-c 2 -n 7", "-c 3"];
+    $niceLevel = (string) (int) ($cfg['moverNice'] ?: 0);
+    $ioLevel = in_array($cfg['moverIO'] ?? "", $allowedIO, true) ? $cfg['moverIO'] : "-c 2 -n 0";
+
     if ($options != "stop") {
         clearstatcache();
         $pid = @file_get_contents("/var/run/mover.pid");
@@ -145,8 +159,6 @@ function startMover()
     }
 
     if ($options == "stop") {
-        $niceLevel = $cfg['moverNice'] ?: "0";
-        $ioLevel = $cfg['moverIO'] ?: "-c 2 -n 0";
         logger("ionice $ioLevel nice -n $niceLevel $mover_str stop");
         passthru("ionice $ioLevel nice -n $niceLevel $mover_str stop");
         exit();
@@ -154,8 +166,6 @@ function startMover()
 
     if ($cron or $cfg['movenow'] == "yes") {
         //exec("echo 'running from cron or move now question is yes' >> /var/log/syslog");
-        $niceLevel = $cfg['moverNice'] ?: "0";
-        $ioLevel = $cfg['moverIO'] ?: "-c 2 -n 0";
 
         if ($cfg['movingThreshold'] >= 0 or $cfg['fillupThreshold'] >= 0 or $cfg['age'] == "yes" or $cfg['sizef'] == "yes" or $cfg['sparsnessf'] == "yes" or $cfg['filelistf'] == "yes" or $cfg['filetypesf'] == "yes" or $cfg['beforescript'] != '' or $cfg['afterscript'] != '' or $cfg['testmode'] == "yes") {
             $age_mover_str = "/usr/local/emhttp/plugins/ca.mover.tuning/age_mover";
@@ -166,8 +176,6 @@ function startMover()
     } else {
         //exec("echo 'Running from button' >> /var/log/syslog");
         //Default "move now" button has been hit.
-        $niceLevel = $cfg['moverNice'] ?: "0";
-        $ioLevel = $cfg['moverIO'] ?: "-c 2 -n 0";
         logger("ionice $ioLevel nice -n $niceLevel $mover_str $options");
         runMover("ionice $ioLevel nice -n $niceLevel $mover_str $options");
     }

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -14,6 +14,12 @@ if (!empty($_GET['check'])) {
     exit;
 }
 
+/**
+ * Write a message to syslog under the "move" tag, when plugin logging is enabled.
+ *
+ * @param string $string Message to log.
+ * @return void
+ */
 function logger($string)
 {
     global $cfg;
@@ -128,7 +134,7 @@ function startMover()
 
     $allowedIO = ["-c 2 -n 0", "-c 2 -n 7", "-c 3"];
     $niceLevel = (string) (int) ($cfg['moverNice'] ?: 0);
-    $ioLevel = in_array($cfg['moverIO'] ?? "", $allowedIO, true) ? $cfg['moverIO'] : "-c 2 -n 0";
+    $ioLevel = in_array($cfg['moverIO'] ?? "", $allowedIO, true) === true ? $cfg['moverIO'] : "-c 2 -n 0";
 
     if ($options != "stop") {
         clearstatcache();

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -133,7 +133,7 @@ function startMover()
     }
 
     $allowedIO = ["-c 2 -n 0", "-c 2 -n 7", "-c 3"];
-    $niceLevel = (string) (int) ($cfg['moverNice'] ?: 0);
+    $niceLevel = (string) (int) ($cfg['moverNice'] ?? 0);
     $ioLevel = in_array($cfg['moverIO'] ?? "", $allowedIO, true) === true ? $cfg['moverIO'] : "-c 2 -n 0";
 
     if ($options != "stop") {

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -23,10 +23,17 @@ function logger($string)
     }
 }
 
-// A mover run can last hours. Under the web UI the request stream is the
-// process's stdout, so a disconnect SIGPIPEs the mover and any before/after
-// script. Detach it instead; CLI and cron keep the blocking behaviour
-// because their stdout is already durable.
+/**
+ * Launch a mover command, detaching it when the caller is a web request.
+ *
+ * A mover run can last hours. Under the web UI the request stream is the
+ * process's stdout, so a disconnect SIGPIPEs the mover and any before/after
+ * script. CLI and cron keep the blocking behaviour because their stdout is
+ * already durable.
+ *
+ * @param string $cmd Full shell command line used to launch the mover.
+ * @return void
+ */
 function runMover($cmd)
 {
     if (PHP_SAPI === 'cli') {

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -23,6 +23,29 @@ function logger($string)
     }
 }
 
+// A mover run can last hours. Under the web UI the request stream is the
+// process's stdout, so a disconnect SIGPIPEs the mover and any before/after
+// script. Detach it instead; CLI and cron keep the blocking behaviour
+// because their stdout is already durable.
+function runMover($cmd)
+{
+    if (PHP_SAPI === 'cli') {
+        passthru($cmd);
+        return;
+    }
+
+    logger("Detached from web request; mover output continues in syslog and the mover log");
+    // stdout is discarded rather than piped to logger: on this path age_mover's
+    // mvlogger already writes each message to syslog, so piping would double it.
+    exec($cmd . " >/dev/null 2>&1 &");
+
+    // Wait for the run to claim the pid file so the page's status poll does
+    // not race a mover that has not started yet.
+    for ($i = 0; $i < 50 && !file_exists("/var/run/mover.pid"); $i++) {
+        usleep(100000);
+    }
+}
+
 //function startMover($options = "start")
 function startMover()
 {
@@ -131,7 +154,7 @@ function startMover()
             $age_mover_str = "/usr/local/emhttp/plugins/ca.mover.tuning/age_mover";
             //exec("echo 'about to hit mover string here: $age_mover_str' >> /var/log/syslog");
             logger("ionice $ioLevel nice -n $niceLevel $age_mover_str $options");
-            passthru("ionice $ioLevel nice -n $niceLevel $age_mover_str $options");
+            runMover("ionice $ioLevel nice -n $niceLevel $age_mover_str $options");
         }
     } else {
         //exec("echo 'Running from button' >> /var/log/syslog");
@@ -139,7 +162,7 @@ function startMover()
         $niceLevel = $cfg['moverNice'] ?: "0";
         $ioLevel = $cfg['moverIO'] ?: "-c 2 -n 0";
         logger("ionice $ioLevel nice -n $niceLevel $mover_str $options");
-        passthru("ionice $ioLevel nice -n $niceLevel $mover_str $options");
+        runMover("ionice $ioLevel nice -n $niceLevel $mover_str $options");
     }
 }
 


### PR DESCRIPTION
Fixes #157.

`mover.php` launches the mover with `passthru()`. Under the web UI that makes the browser request's
output stream the process's stdout, so a mover run — which can last hours — stays tied to the
lifetime of a browser request. When that connection goes away, the mover and any before/after script
launched via `eval` take SIGPIPE.

For the qBittorrent mover scripts the consequence is that the after script, which is what resumes
paused torrents, is killed on its first `echo` and the torrents stay paused with nothing recorded.

## What this changes

Adds a small `runMover()` helper and uses it at the two long-running launch sites (the `age_mover`
path and the stock-mover path). The short-lived `stop` call is left on `passthru()`.

- **Web requests** detach: `exec($cmd . " >/dev/null 2>&1 &")`.
- **CLI and cron are untouched** and still use `passthru()`, because their stdout is already durable
  — cron is `... |& logger -t move`, which always has a reader. This matters because that launch
  site is shared by both cron and the button, so detaching unconditionally would have changed
  cron's behaviour too.

Notes for review:

- **`moveNow.php` precedent** — it uses the same detached shape, but appears to be unreferenced:
  `moveNow()` at `Mover.tuning.page:81` is never called and posts to a malformed URL. Worth deciding
  whether to converge or remove it.
- **`PHP_SAPI` rather than the existing `$cron` / `$bash` flags** — those derive from `argv[1]`, and a
  plain CLI `mover start` sets neither, so they would misclassify it as a web request.
- **stdout discarded, not piped to `logger`** — `mvlogger` already writes each message to syslog on
  this path, so piping would double every line.
- **Short wait for the pid file** — detaching returns immediately, which could race the status check
  at `Mover.tuning.page:160` and make a running mover look finished. The loop exits as soon as
  `/var/run/mover.pid` appears, 5s ceiling. Edge case: if `age_mover`'s own already-running guard
  fires, no pid file is written and it waits out the full ceiling.

## Testing

Unraid 7.3.2, plugin 2026.08.15. `php -l` passes.

Detached invocation, measured directly:

```
sh returned          +1 ms      fully detached
pid file appeared   103 ms      2 of 50 wait iterations
run completed        ~19 s      before/after scripts both ran; 248 torrents resumed; fclones log written
```

Through the UI, patched file deployed and the start button clicked:

```
08:45:53  Manually executed (Move button)
08:45:53  Detached from web request; mover output continues in syslog and the mover log
08:45:59  Before script finished
08:46:11  After script finished with result: OK
```

Unpatched, that same button gave `After script finished with result: 1` seven milliseconds after
launch, with no output at all. The `PHP_SAPI` branch fires as intended and the status poll behaves —
no false "finished".

Later commits: `6dade32` switches the pid poll to `file_exists(...) === false` for Codacy, `a1a4f79`
adds a docblock for the docstring-coverage check.

The wait loop is inferred from what the status poll appears to need, so it is the part most worth
checking against how that polling is meant to behave.

Scanner findings are answered in the comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Web-triggered mover operations now run in the background, keeping the interface responsive.
  * Command-line mover operations continue to wait for completion.
  * Mover output is redirected, and execution status is logged for improved reliability.
  * Mover commands and priority settings are validated before execution.
  * Stop operations continue to run synchronously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




