### PR TITLE
Fix symlink creation for age_mover to point to the correct plugin path

### DIFF
--- a/plugins/ca.mover.tuning.plg
+++ b/plugins/ca.mover.tuning.plg
@@ -689,8 +689,10 @@ chmod +x /usr/local/emhttp/plugins/&name;/share_mover
 chmod +x /usr/local/emhttp/plugins/&name;/debug_mover
 
 # Install symlink: /usr/local/sbin/age_mover → plugin age_mover
+if [[ -x /usr/local/emhttp/plugins/&name;/age_mover ]]; then
   ln -sf /usr/local/emhttp/plugins/&name;/age_mover /usr/local/sbin/age_mover
   echo "Created symlink: /usr/local/sbin/age_mover → plugin age_mover"
+fi
 
 # Refresh cron
 /usr/local/sbin/update_cron

--- a/plugins/ca.mover.tuning.plg
+++ b/plugins/ca.mover.tuning.plg
@@ -688,11 +688,9 @@ chmod +x /usr/local/emhttp/plugins/&name;/mover
 chmod +x /usr/local/emhttp/plugins/&name;/share_mover
 chmod +x /usr/local/emhttp/plugins/&name;/debug_mover
 
-# Install symlink: /usr/local/sbin/age_mover → plugin mover
-if [[ -x /usr/local/emhttp/plugins/&name;/mover ]]; then
-  ln -sf /usr/local/emhttp/plugins/&name;/mover /usr/local/sbin/age_mover
-  echo "Created symlink: /usr/local/sbin/age_mover → plugin mover (for backward compatibility)"
-fi
+# Install symlink: /usr/local/sbin/age_mover → plugin age_mover
+  ln -sf /usr/local/emhttp/plugins/&name;/age_mover /usr/local/sbin/age_mover
+  echo "Created symlink: /usr/local/sbin/age_mover → plugin age_mover"
 
 # Refresh cron
 /usr/local/sbin/update_cron


### PR DESCRIPTION
Signed-off-by: DaRK AnGeL <28630321+masterwishx@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-install setup to consistently provide the `age_mover` command.
  * Improved command availability by linking directly to the intended executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->