### PR TITLE
Report the after script's real exit code instead of always 1

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -2379,7 +2379,9 @@ start() {
         if [ -f "$AFTERSCRIPT" ] && [ -x "$AFTERSCRIPT" ]; then
             mvlogger "Launching after script: $AFTERSCRIPT"
             eval "$AFTERSCRIPT"
-            mvlogger "After script finished with result: $([ $? = 0 ] && echo "OK" || echo "$?")"
+            rc=$?
+            # rc is read instead of $?: [ overwrites $? before the || branch runs.
+            mvlogger "After script finished with result: $([ "$rc" = 0 ] && echo "OK" || echo "$rc")"
         else
             mvlogger "After script file $AFTERSCRIPT does not exist or is not executable."
             mvlogger "Skipping"


### PR DESCRIPTION
Fixes #156.

`age_mover` reports the after script's status like this:

```bash
mvlogger "After script finished with result: $([ $? = 0 ] && echo "OK" || echo "$?")"
```

`$?` is correct when `[` tests it, but `[` then overwrites it, so by the time the `||` branch runs,
`echo "$?"` prints the status of `[` — always `1`. A script killed by a signal, one that ran
`exit 2`, and one that genuinely returned 1 are indistinguishable in the log. Capturing the status
before the test fixes it.

## Testing

Both forms driven with the same after script, exit code varied:

```
real=0    old=OK   new=OK
real=1    old=1    new=1
real=2    old=1    new=2
real=42   old=1    new=42
real=141  old=1    new=141
```

141 is the case that prompted the report — SIGPIPE, flattened to `1` by the old form.

`shellcheck` drops one finding on this file (SC2181) and adds none.

## Notes

- Every launch path is affected equally, since the reporting lives in `age_mover`: cron, `mover start`
  from the CLI and the Move Now button all logged the masked value.
- Separate from #157. #158 removed the SIGPIPE that produced that particular `141`; it did not touch
  the masking, which applies to any non-zero status on any path.
- The before script block at `age_mover:2342` has the same shape but logs no status at all, so
  nothing is masked there. Reporting both hooks uniformly is a larger change than this fix and
  better done on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved after-script result handling so the correct exit status is captured and logged reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->