### PR TITLE
Measure the ignore list in a single du so hardlinked and nested entries are not counted twice

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -233,7 +233,9 @@ human_to_bytes() {
 # Skip-list lines for this share. Literal match, not regex: share names may hold
 # regex metacharacters, and an unanchored substring also matches sibling shares.
 skiplist_share_lines() {
-    awk -v pfx="/mnt/$1/$2" '
+    # prefix via ENVIRON, not -v: awk expands escape sequences in a -v value
+    SKIPLIST_PFX="/mnt/$1/$2" awk '
+        BEGIN { pfx = ENVIRON["SKIPLIST_PFX"] }
         { sub(/\r$/, "") }   # the gate calls this before the CRLF fix below
         index($0, pfx) == 1 && (length($0) == length(pfx) || substr($0, length(pfx) + 1, 1) == "/")
     ' "$3"

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1335,8 +1335,10 @@ createFilteredFilelist() {
             done <<<"$(skiplist_share_lines "$PRIMARYSTORAGENAME" "$SHARENAME" "$SKIPFILESLIST")"
 
             if [ ${#SKIPPED_MEASURE_PATHS[@]} -gt 0 ]; then
-                TOTAL_SKIPPED_PATH_RESERVED_SPACE="$(printf '%s\0' "${SKIPPED_MEASURE_PATHS[@]}" | du -sc --block-size=1 --files0-from=- 2>/dev/null | tail -n1 | cut -f1)"
-                if [ -z "$TOTAL_SKIPPED_PATH_RESERVED_SPACE" ]; then
+                # du exits nonzero on a partial read while still printing a total
+                if SKIPPED_PATHS_DU="$(printf '%s\0' "${SKIPPED_MEASURE_PATHS[@]}" | du -sc --block-size=1 --files0-from=- 2>/dev/null)"; then
+                    TOTAL_SKIPPED_PATH_RESERVED_SPACE=$(tail -n1 <<<"$SKIPPED_PATHS_DU" | cut -f1)
+                else
                     mvlogger "Error calculating size for ${SKIPFILESLIST}"
                     TOTAL_SKIPPED_PATH_RESERVED_SPACE=0
                 fi
@@ -1351,7 +1353,8 @@ createFilteredFilelist() {
             mvlogger "Skipping Filetypes from List. File sizes are taken into account for the calculation of the threshold"
             for ext in $([ $overrideFlag = 1 ] && echo -n "$SKIPFILETYPES") $(echo -n "$globalSkipFileTypes"); do
                 FINDSTR="$FINDSTR -not -name '*.$ext'"
-                if SKIPPED_FILETYPES_RESERVED_SPACE="$(find "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" -type f -name "*.$ext" -print0 | du -c --block-size=1 --files0-from=- 2>/dev/null | tail -n1 | cut -f1)" && [ -n "$SKIPPED_FILETYPES_RESERVED_SPACE" ]; then
+                if SKIPPED_FILETYPES_DU="$(find "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" -type f -name "*.$ext" -print0 | du -c --block-size=1 --files0-from=- 2>/dev/null)" &&
+                    SKIPPED_FILETYPES_RESERVED_SPACE=$(tail -n1 <<<"$SKIPPED_FILETYPES_DU" | cut -f1) && [ -n "$SKIPPED_FILETYPES_RESERVED_SPACE" ]; then
                     echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|$SKIPPED_FILETYPES_RESERVED_SPACE|0|0|0|f|$SHAREPATH/**/*.$ext" >>"$FILTERED_FILELIST"
                     TOTAL_SKIPPED_FILETYPES_RESERVED_SPACE=$((TOTAL_SKIPPED_FILETYPES_RESERVED_SPACE + SKIPPED_FILETYPES_RESERVED_SPACE))
                 else
@@ -1673,7 +1676,7 @@ decideMoveActions() {
                         pool_stats[$1]["total_size_from_secondary"] += $8
                     }
                 } else {
-                    if (REBALANCESHARES == "yes") {
+                    if (REBALANCESHARES == "yes" && $4 != "skipped") {
                         action = ($4 == "only" || ($4 == "prefer" && remaining_bytes_used[$1] <= $6)) ? "move unattended to primary" : "move unattended to secondary"
                         if (action == "move unattended to primary" && SYNCHRONIZECACHE == "yes" && $4 != "only" ) {
                             source = storage_path

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -230,6 +230,15 @@ human_to_bytes() {
     numfmt --from=iec "$input"
 }
 
+# Skip-list lines belonging to this share. Matched literally, not as a regex:
+# a share name may contain regex metacharacters, and an unanchored substring
+# also matches sibling shares that merely start with the same text.
+skiplist_share_lines() {
+    awk -v pfx="/mnt/$1/$2" '
+        index($0, pfx) == 1 && (length($0) == length(pfx) || substr($0, length(pfx) + 1, 1) == "/")
+    ' "$3"
+}
+
 # Sanitize input filename to prevent attacks
 validate_filename() {
     local filename="$1"
@@ -1263,7 +1272,7 @@ createFilteredFilelist() {
         FINDSTR="$FINDSTR -not -name '.placeholder'" #do not move placeholders
 
         # Add files from ignore list
-        if { [ -z "$OMOVERTHRESH" ] || [ "$POOLPCTUSED" -le "$OMOVERTHRESH" ]; } && { [ "$SHAREUSECACHE" = "prefer" ] || [ "$SHAREUSECACHE" = "yes" ]; } && [ -f "$SKIPFILESLIST" ] && grep -q "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" "$SKIPFILESLIST"; then
+        if { [ -z "$OMOVERTHRESH" ] || [ "$POOLPCTUSED" -le "$OMOVERTHRESH" ]; } && { [ "$SHAREUSECACHE" = "prefer" ] || [ "$SHAREUSECACHE" = "yes" ]; } && [ -f "$SKIPFILESLIST" ] && [ -n "$(skiplist_share_lines "$PRIMARYSTORAGENAME" "$SHARENAME" "$SKIPFILESLIST")" ]; then
             mvlogger "Skipping Files from List. File size are taken into account in the calculation of the threshold"
             mvlogger "List Path: ${SKIPFILESLIST}:"
 
@@ -1277,6 +1286,7 @@ createFilteredFilelist() {
             fi
 
             TOTAL_SKIPPED_PATH_RESERVED_SPACE=0
+            SKIPPED_MEASURE_PATHS=()
             while IFS= read -r skipped_path; do
 
                 # Check if the last path component contains a wildcard pattern
@@ -1289,7 +1299,6 @@ createFilteredFilelist() {
                     continue
                 fi
 
-                SKIPPED_PATH_RESERVED_SPACE=""
                 # Remove potential trailing /, *, /* characters from the skipped_path
                 skipped_path="${skipped_path%"${skipped_path##*[!/*]}"}"
                 #skipped_path="${skipped_path%/}" # Remove potential trailing slash
@@ -1297,7 +1306,10 @@ createFilteredFilelist() {
 
                 if [[ -d "${skipped_path}" || -f "${skipped_path}" ]]; then
                     mvDebuglogger "${skipped_path} - exists" "Skipped Path"
-                    SKIPPED_PATH_RESERVED_SPACE="$(du -sh "${skipped_path}" | awk '{print $1}' | human_to_bytes)"
+                    # Measured after the loop in a single du. du de-duplicates inodes
+                    # only within one invocation, so a per-path call counts a hardlinked
+                    # or nested entry once per listed path it is reachable from.
+                    SKIPPED_MEASURE_PATHS+=("${skipped_path}")
 
                     if [[ -d "${skipped_path}" ]]; then
                         mvDebuglogger "${skipped_path} - is a Folder" "Skipped Path"
@@ -1315,14 +1327,20 @@ createFilteredFilelist() {
                     continue
                 fi
 
-                if [ -n "$SKIPPED_PATH_RESERVED_SPACE" ]; then
-                    echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|$SKIPPED_PATH_RESERVED_SPACE|0|0|0|$filetype|${skipped_path}" >>"$FILTERED_FILELIST"
-                    TOTAL_SKIPPED_PATH_RESERVED_SPACE=$((TOTAL_SKIPPED_PATH_RESERVED_SPACE + SKIPPED_PATH_RESERVED_SPACE))
-                else
-                    mvlogger "Error calculating size for $skipped_path"
+                # Exclusion-only row. The size for the whole list is carried by the
+                # aggregate row below, so these rows cannot double-count in pool_sums.
+                echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|0|0|0|0|$filetype|${skipped_path}" >>"$FILTERED_FILELIST"
+            done <<<"$(skiplist_share_lines "$PRIMARYSTORAGENAME" "$SHARENAME" "$SKIPFILESLIST")"
+
+            if [ ${#SKIPPED_MEASURE_PATHS[@]} -gt 0 ]; then
+                TOTAL_SKIPPED_PATH_RESERVED_SPACE="$(printf '%s\0' "${SKIPPED_MEASURE_PATHS[@]}" | du -sc --block-size=1 --files0-from=- 2>/dev/null | tail -n1 | cut -f1)"
+                if [ -z "$TOTAL_SKIPPED_PATH_RESERVED_SPACE" ]; then
+                    mvlogger "Error calculating size for ${SKIPFILESLIST}"
+                    TOTAL_SKIPPED_PATH_RESERVED_SPACE=0
                 fi
-            done <<<"$(grep "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" "${SKIPFILESLIST}")"
-            mvlogger "    Ignored files are using $(bytes_to_human $TOTAL_SKIPPED_PATH_RESERVED_SPACE)"
+                echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|$TOTAL_SKIPPED_PATH_RESERVED_SPACE|0|0|0|f|${SHAREPATH}/ ignored files" >>"$FILTERED_FILELIST"
+            fi
+            mvlogger "    Ignored files are using $(bytes_to_human "$TOTAL_SKIPPED_PATH_RESERVED_SPACE")"
         fi
 
         #Add Skipfilelist to find string
@@ -1331,7 +1349,7 @@ createFilteredFilelist() {
             mvlogger "Skipping Filetypes from List. File sizes are taken into account for the calculation of the threshold"
             for ext in $([ $overrideFlag = 1 ] && echo -n "$SKIPFILETYPES") $(echo -n "$globalSkipFileTypes"); do
                 FINDSTR="$FINDSTR -not -name '*.$ext'"
-                if SKIPPED_FILETYPES_RESERVED_SPACE="$(find "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" -type f -name '*.$ext' -print0 | xargs -0 du -sh | awk '{print $1}' | human_to_bytes | awk '{ sum += $1 } END { print sum }')"; then
+                if SKIPPED_FILETYPES_RESERVED_SPACE="$(find "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" -type f -name "*.$ext" -print0 | du -c --block-size=1 --files0-from=- 2>/dev/null | tail -n1 | cut -f1)" && [ -n "$SKIPPED_FILETYPES_RESERVED_SPACE" ]; then
                     echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|$SKIPPED_FILETYPES_RESERVED_SPACE|0|0|0|f|$SHAREPATH/**/*.$ext" >>"$FILTERED_FILELIST"
                     TOTAL_SKIPPED_FILETYPES_RESERVED_SPACE=$((TOTAL_SKIPPED_FILETYPES_RESERVED_SPACE + SKIPPED_FILETYPES_RESERVED_SPACE))
                 else

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -230,11 +230,11 @@ human_to_bytes() {
     numfmt --from=iec "$input"
 }
 
-# Skip-list lines belonging to this share. Matched literally, not as a regex:
-# a share name may contain regex metacharacters, and an unanchored substring
-# also matches sibling shares that merely start with the same text.
+# Skip-list lines for this share. Literal match, not regex: share names may hold
+# regex metacharacters, and an unanchored substring also matches sibling shares.
 skiplist_share_lines() {
     awk -v pfx="/mnt/$1/$2" '
+        { sub(/\r$/, "") }   # the gate calls this before the CRLF fix below
         index($0, pfx) == 1 && (length($0) == length(pfx) || substr($0, length(pfx) + 1, 1) == "/")
     ' "$3"
 }


### PR DESCRIPTION
`age_mover` measures the ignore list with one `du` per line (`:1300`) and writes each result into the
filtered list as `FILESIZE` (`:1319`). `du` de-duplicates inodes only within a single invocation, so an
inode reachable from two listed paths is counted once per path — hardlinks across two listed trees, or a
parent and its own child both listed.

That column drives behaviour, not just the log line: `pool_sums[$1] += $8` (`:1541`) sums it, and for
`cache:yes` `remaining_bytes_used = pool_bytes_used - pool_sums` (`:1549`) gates every move (`:1602`). An
overstated total makes the pool look closer to the freeing threshold than it is, so the mover stops early.
The hardlink de-duplication already at `:1531` cannot catch it — skipped rows are written with `NBLINKS`
and `INODE` hardcoded to `0`, so `$10 > 1` is never true for them.

## What this changes

- Collect the listed paths during the loop and emit them as exclusion-only rows with `FILESIZE 0` — what
  the wildcard branch at `:1288` already does — plus one aggregate row measured by a single
  `du -sc --block-size=1 --files0-from=-`.
- `:1266` / `:1324` — match the share prefix literally. `grep "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}"`
  is unanchored, so share `media` also pulls in `media_backup` lines. A regex anchor is not enough here:
  share names may contain regex metacharacters, so `media.old` would still match `mediaXold`.
- `:1334` — `-name '*.$ext'` is single-quoted, so `$ext` never expands and `find` matches nothing.
  `xargs -0` without `-r` then runs `du -sh` with **no arguments**, which measures the mover's current
  working directory and uses that as the reserved size, once per configured extension. Quoted the glob
  and replaced the `xargs` split with one `du`.

`--block-size=1` also drops the `du -sh` round trip, which carried only two significant digits — `4.6T`
quantises to about ±50 GiB before `human_to_bytes` parses it back.

Notes for review:

- Only `age_mover` is touched; `version` and `md5` in the `.plg` are left alone.
- Correcting `:1334` is a behaviour change for anyone using skipped filetypes — that branch has never
  contributed real numbers, only the working-directory size.
- `shellcheck` already flags `:1334` as SC2016. Findings go 113 → 112, none new.

## Testing

Unraid 7.3.2, plugin 2026.08.29, `bash -n` passes. Fixtures built on a tmpfs path — ZFS compression and
delayed allocation both skew `du` block accounting, so a pool-backed fixture is not reproducible.

Ignore list of: two paths sharing one hardlinked 4 MiB file, a parent and its own child, two independent
directories, a path containing a space, a wildcard, a nonexistent path, and a line belonging to sibling
share `testshare_backup`.

```
                                      before      after       truth
ignore-list total                     33554432    20971520    20971520
control, no hardlinks or nesting      12582912    12582912    12582912
share media.old, sibling mediaXold     8388608     4194304     4194304
skipped filetypes, CWD holding 32M    33554432     8388608     8388608
```

The control case is the important one: with neither hardlinks nor nesting, before and after agree exactly,
so lists that were already measured correctly are unaffected.

Decision arithmetic run through `:1531-1558` and `:1602` unmodified, at the scale of a reported
4.6 TiB / 2.2 TiB list — pool 8.00 TiB used, freeing threshold 5.00 TiB, ten 100 GiB movable files:

```
before  skipped=4.60 TiB   moved=0  kept=10   remaining 8.00 TiB   never starts
after   skipped=2.20 TiB   moved=8  kept=2    remaining 4.82 TiB   stops at the threshold
```

`FINDSTR` is byte-identical before and after apart from losing the `testshare_backup` entry, which was
excluding a path outside the share being scanned. Also checked: no lines for the share, all paths
nonexistent, wildcard-only list, CRLF endings, trailing `/` and `/*` — no rows where none should be, no
aggregate row when nothing was measurable, and identical results before and after.

Distinct from #151, which is the execution pass: files the hardlink guard at `:1911` declines to move are
still counted in the completion notification. Neither fix resolves the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skip-list matching to prevent similarly named shares or unrelated paths from being incorrectly included.
  * Added support for skip lists using Windows-style line endings.
  * Improved storage-size reporting for skipped paths and file types, including clearer per-path exclusions and aggregate totals.
  * Reduced inconsistencies in skipped-content size calculations.
  * Prevented unattended storage balancing from rebalancing items marked as skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->