### PR TITLE
Exclude an ignored directory itself, not just its contents

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -258,6 +258,13 @@ validate_filename() {
     return 0
 }
 
+# find's -path glob and the eval each strip one level, so a literal backslash
+# needs four. Order matters: backslash first, then '['.
+escape_find_path() {
+    FIND_PATH_ESC=${1//\\/\\\\\\\\}
+    FIND_PATH_ESC=${FIND_PATH_ESC//[/\\[}
+}
+
 # Function for verbose output and logging
 # $1 = message text
 # $2 = optional notify level
@@ -1284,7 +1291,8 @@ createFilteredFilelist() {
                 if [[ "$lastcomponent" == *"*"* ]]; then
                     mvDebuglogger "${skipped_path} - is a Wildcard Pattern" "Skipped Path"
                     mvlogger "Skipping wildcard pattern: ${skipped_path} (size not tracked)"
-                    FINDSTR="$FINDSTR -not -path \"${skipped_path//[/\\[}\"" # fixed when folder contain '['
+                    escape_find_path "$skipped_path"
+                    FINDSTR="$FINDSTR -not -path \"$FIND_PATH_ESC\""
                     echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|0|0|0|0|f|${skipped_path}" >>"$FILTERED_FILELIST"
                     continue
                 fi
@@ -1302,7 +1310,8 @@ createFilteredFilelist() {
                     if [[ -d "${skipped_path}" ]]; then
                         mvDebuglogger "${skipped_path} - is a Folder" "Skipped Path"
                         # -path "dir/*" matches the contents only, never the dir node
-                        FINDSTR="$FINDSTR -not -path \"${skipped_path//[/\\[}\""
+                        escape_find_path "$skipped_path"
+                        FINDSTR="$FINDSTR -not -path \"$FIND_PATH_ESC\""
                         # Add /* at the end for better reading in Mover_action file
                         skipped_path="${skipped_path}/*"
                         filetype="d"
@@ -1311,7 +1320,8 @@ createFilteredFilelist() {
                         filetype="f"
                     fi
 
-                    FINDSTR="$FINDSTR -not -path \"${skipped_path//[/\\[}\"" # fixed when folder contain '['
+                    escape_find_path "$skipped_path"
+                    FINDSTR="$FINDSTR -not -path \"$FIND_PATH_ESC\""
                 else
                     mvDebuglogger "${skipped_path} - does not exist?" "Skipped Path"
                     continue

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1301,6 +1301,8 @@ createFilteredFilelist() {
 
                     if [[ -d "${skipped_path}" ]]; then
                         mvDebuglogger "${skipped_path} - is a Folder" "Skipped Path"
+                        # -path "dir/*" matches the contents only, never the dir node
+                        FINDSTR="$FINDSTR -not -path \"${skipped_path//[/\\[}\""
                         # Add /* at the end for better reading in Mover_action file
                         skipped_path="${skipped_path}/*"
                         filetype="d"


### PR DESCRIPTION
Relates to #12 — two reproducible causes, not necessarily the whole issue.

**1. An ignored directory's own node is never excluded.** A directory entry becomes `-not -path "dir/*"`, which matches the contents but never the directory node, so an ignored empty folder is still returned as movable (with Move Empty Folders on).

**2. A backslash in an ignore-list path silently fails to exclude.** The pattern passes through `eval` and then find's `-path` glob, and each strips one level, so a literal `\` needs four. `AC\DC - Song.mp3` on the ignore list gets moved anyway.

```
ENTRY                     master     this PR
ign_empty (dir node)      returned   excluded
AC\DC - Song.mp3          returned   excluded
ign_full/sub/a.mkv        excluded   excluded
What? - Track.mp3         excluded   excluded
Album [2024]/c.mp3        excluded   excluded
keep_empty    (control)   returned   returned
keep_full/b.mkv (control) returned   returned
keep.mp3      (control)   returned   returned
```

Escaping moved into one helper, since three call sites build the same pattern. Existing `[` handling is unchanged and still covered above.

Unraid 7.3.2, GNU find 4.10.0, `bash -n` passes. Independent of #163 — merges cleanly in either order.
