### PR TITLE
Fix mover threshold evaluation to use projected pool usage correctly

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -995,8 +995,8 @@ createFilteredFilelist() {
 
         # Calculate primary storage size thresholds in bytes
         if [ "$SHAREUSECACHE" = "prefer" ]; then
-            # Calculate the real free space by considering an upper limit of fillup (95%) minus pool used usage for later calculations
-            PRIMARYSIZETHRESH=$(((POOLSIZE - POOLBYTEUSED) * PREFER_FILLUPPCTLIMIT / 100))
+            # absolute pool-usage target to fill up to, not a share of free space
+            PRIMARYSIZETHRESH=$((POOLSIZE * PREFER_FILLUPPCTLIMIT / 100))
             MOVESIZETHRESH=$((POOLSIZE * PREFER_MOVINGPCTTHRESHOLD / 100))
         else
             PRIMARYSIZETHRESH=$((POOLSIZE * FREEINGPCTLIMIT / 100))
@@ -1458,6 +1458,13 @@ createFilteredFilelist() {
         sort -t '|' -k1,1 -k4,4 -k5,5nr -k11,11 -o "$FILTERED_FILELIST" "$FILTERED_FILELIST"
         rm "$tempfile1" "$tempfile2"
     fi
+
+    # cache:yes is walked oldest-first so projected pool usage sheds the oldest files;
+    # every other mode keeps newest-first (cache:prefer primes the newest)
+    reorderfile=$(mktemp)
+    awk -F'|' 'NR==1 || $4!="yes"' "$FILTERED_FILELIST" >"$reorderfile"
+    awk -F'|' 'NR>1 && $4=="yes"' "$FILTERED_FILELIST" | sort -t '|' -k1,1 -k5,5n -k11,11 >>"$reorderfile"
+    mv -f "$reorderfile" "$FILTERED_FILELIST"
 }
 
 decideMoveActions() {
@@ -1543,19 +1550,10 @@ decideMoveActions() {
             # Actual pool usage before mover starts (from POOLUSED)
             pool_bytes_used[$1] = $7
 
-            # Projected pool usage after this file is processed
-            if ($4 == "yes") {
-                # yes = mover empties cache → subtract cumulative moved size
-                remaining_bytes_used[$1] = pool_bytes_used[$1] - pool_sums[$1]
-            }
-            else if ($4 == "prefer") {
-                # prefer = mover fills cache → add cumulative moved size
-                remaining_bytes_used[$1] = pool_bytes_used[$1] + pool_sums[$1]
-            }
-            else {
-                # others (only/skipped) = no movement → usage unchanged
-                remaining_bytes_used[$1] = pool_bytes_used[$1]
-            }
+            # Projected pool usage from the moves planned so far. net_delta is signed -
+            # arrivals on the primary add, departures subtract - so a pool carrying both
+            # cache:yes and cache:prefer shares stays consistent across both.
+            remaining_bytes_used[$1] = pool_bytes_used[$1] + net_delta[$1]
 
             ### Check if share has Sync override ###
             # Set current sharename
@@ -1621,6 +1619,7 @@ decideMoveActions() {
                 if (action == "move from primary") {
                     source = storage_path
                     destination = "/mnt/" $2
+                    net_delta[$1] -= $8
                     if ($12 == "d") {
                         pool_stats[$1]["folders_from_primary"] += 1
                     } else {
@@ -1642,6 +1641,7 @@ decideMoveActions() {
                     if (action == "move from secondary") {
                         source = storage_path
                         destination = "/mnt/" $1
+                        net_delta[$1] += $8
                         if (SYNCHRONIZECACHE == "yes" && ($4 != "only" && $4 != "skipped")) {
                             action = "sync from secondary"
                         }
@@ -1658,6 +1658,8 @@ decideMoveActions() {
                         if (action == "move unattended to primary" && SYNCHRONIZECACHE == "yes" && $4 != "only" ) {
                             source = storage_path
                             destination = "/mnt/" $1
+                            # the follow-up is a sync, which keeps the file on the primary
+                            net_delta[$1] += $8
                             if ($12 == "d") {
                                 pool_stats[$1]["folders_from_unattended"] += 1
                             } else {
@@ -1673,6 +1675,7 @@ decideMoveActions() {
                             if (action == "move unattended to primary") {
                                 source = storage_path
                                 destination = "/mnt/" $1
+                                net_delta[$1] += $8
                             } else {
                                 action = "move unattended to secondary"
                                 source = storage_path


### PR DESCRIPTION
### Problem

Reported by User 0815 on the forum with before/after logs: on a `cache:yes` share, 2026.08.21 moves 76GiB and 2026.08.29 moves nothing — same 335-file scan, same pool.

`cache:prefer` stops filling too, once the pool passes `POOLSIZE * fillup/(100+fillup)`.

### Cause

Projected pool usage is the right model. Three things stop it working:

**1. `pool_sums` is cumulative *scanned* size, not moved size.** `:1541` sums every row, including the `only`/`skipped` rows that are never moved and sort first (`-k4,4`). On the reported system that alone kills the gate:

```
pool used       819.9 GiB
freeing thresh  707.0 GiB    -> headroom 112.8 GiB
only rows       117.3 GiB    (appdata 1.3 + domains 58 + isos 23 + system 35)

819.9 - 117.3 = 702.6  <  707.0   ->  every file "keep on primary"
```

**2. `cache:yes` is walked newest-first** (`:1408`, `-k5,5nr`). A projected-usage test on a newest-first list moves the newest files — the opposite of *"Auto will move from the oldest to the most recent, until threshold is met"*.

**3. The `cache:prefer` threshold is a share of free space.** `:999` computes `(POOLSIZE - POOLUSED) * fillup% / 100`, while `:1122` compares the same setting directly against `POOLPCTUSED` as an absolute target. The gate cannot be true once the pool is past `POOLSIZE * fillup/(100+fillup)`.

### Fix

- track a signed `net_delta` per pool — arrivals on the primary add, departures subtract — and project as `pool_bytes_used + net_delta`, so a pool carrying both `cache:yes` and `cache:prefer` shares stays consistent. This replaces the per-mode sign, which double-counted when both modes shared a pool
- re-sort `cache:yes` rows oldest-first after filtering; every other mode keeps newest-first
- make the prefer threshold absolute, matching `:1122` and the help text

The three decision gates are unchanged from 2026.08.29.

### Testing

Decision block run under GNU Awk 5.4.0 against synthetic file lists; `bash -n` clean on 5.3.15.

| case | before | after |
| --- | --- | --- |
| 2026.08.21 scenario (830GiB used, 754GiB threshold, really moved one 76GiB file) | nothing moves | that file moves |
| reported scenario, full pool modelled | nothing moves | 4 oldest move, 4 newest kept |
| age/size filter leaves 100GiB of candidates | nothing moves | all 100GiB moves |
| `cache:prefer` | nothing moves | fills to the threshold |

The reorder was checked separately: `yes` rows come out oldest-first with other modes, the header and the row count untouched.

### Known behaviour

`cache:prefer` can admit one file past the fill threshold. The projection is evaluated before the current file, so the last file accepted may carry the pool over the cap — with 25GiB files and a 471.5GiB target starting from 400GiB used, it stops at 475GiB. The one-file overshoot is not new; the absolute threshold makes it visible, where the previous free-space threshold left the effective cap near 97% and hid it.

`cache:yes` is deliberately not symmetric: its gate asks whether the pool is still above the freeing threshold, so passing the target by one file is intended — testing the file first would stop a file early and leave the pool permanently above the threshold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache fill-up threshold calculations for more accurate mover decisions.
  * Corrected projected pool usage when evaluating files marked for cache retention or preference.
  * Ensured planned moves consistently account for their net impact on pool usage.
  * Adjusted file processing order so cache-retained files are handled oldest first, while other modes preserve their existing order.
  * Improved consistency when determining which files should be moved as pool usage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->