### PR TITLE
Measure cache:only and hidden-file sizes in exact bytes

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -230,6 +230,16 @@ human_to_bytes() {
     numfmt --from=iec "$input"
 }
 
+# Exact byte total from du. Never parse `du -h` here: it carries two significant
+# digits, so a 58.4GiB share reads back as 62277025792 and the reserved space it
+# feeds into the threshold is always over-stated.
+du_total_bytes() {
+    local out
+    # du prints a total even on a partial read, so the status must be du's own
+    out=$(du -c --block-size=1 "$@" 2>/dev/null) || return 1
+    tail -n1 <<<"$out" | cut -f1
+}
+
 # Skip-list lines for this share. Literal match, not regex: share names may hold
 # regex metacharacters, and an unanchored substring also matches sibling shares.
 skiplist_share_lines() {
@@ -1179,17 +1189,22 @@ createFilteredFilelist() {
                     # Share size calculation (only if enabled)
                     if [ "$SHARE_CALCULATION" = "yes" ]; then
                         # Try ZFS dataset first
+                        CACHESHARERESERVEDSPACE=""
                         if is_zfs_mountpoint_fstype "/mnt/$PRIMARYSTORAGENAME"; then
                             mvlogger "Calculating zfs share usage..."
                             # if error on command then share can be a folder instead dataset
                             if ! CACHESHARERESERVEDSPACE=$(zfs list -Hpo used "$PRIMARYSTORAGENAME/$SHARENAME"); then
                                 mvlogger "Warning: Share is currently a folder. Convert it to a dataset for better performance."
-                                mvlogger "Calculating share usage... (can take a moment)"
-                                CACHESHARERESERVEDSPACE=$(du -sh "$SHAREPATH" | awk '{print $1}' | human_to_bytes)
+                                CACHESHARERESERVEDSPACE=""
                             fi
-                        else
+                        fi
+                        # single du fallback for both the non-zfs pool and the zfs-folder case
+                        if [ -z "$CACHESHARERESERVEDSPACE" ]; then
                             mvlogger "Calculating share usage... (can take a moment)"
-                            CACHESHARERESERVEDSPACE=$(du -sh "$SHAREPATH" | awk '{print $1}' | human_to_bytes)
+                            if ! CACHESHARERESERVEDSPACE=$(du_total_bytes -s "$SHAREPATH"); then
+                                mvlogger "Error calculating size for $SHAREPATH"
+                                CACHESHARERESERVEDSPACE=0
+                            fi
                         fi
                     else
                         mvlogger "Share size calculation disabled for this share."
@@ -1272,7 +1287,10 @@ createFilteredFilelist() {
         if { [ -z "$OMOVERTHRESH" ] || [ "$POOLPCTUSED" -le "$OMOVERTHRESH" ]; } && { [ "$SHAREUSECACHE" = "prefer" ] || [ "$SHAREUSECACHE" = "yes" ]; } && [ "$IGNOREHIDDENFILES" == "yes" ]; then
             mvlogger "Skipping Hidden Files. File size are taken into account in the calculation of the threshold"
             FINDSTR="$FINDSTR -not -path '*/\.*'"
-            HIDDENFILES_RESERVED_SPACE=$(find "/mnt/$PRIMARYSTORAGENAME/$SHARENAME" -type f -name '.*' -print0 | du -ch --files0-from=- | awk '/total$/ {print $1}' | human_to_bytes)
+            if ! HIDDENFILES_RESERVED_SPACE=$(find "/mnt/$PRIMARYSTORAGENAME/$SHARENAME" -type f -name '.*' -print0 | du_total_bytes --files0-from=-); then
+                mvlogger "Error calculating size for hidden files in ${SHAREPATH}"
+                HIDDENFILES_RESERVED_SPACE=0
+            fi
             echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|$HIDDENFILES_RESERVED_SPACE|0|0|0|f|${SHAREPATH}/ hidden files" >>"$FILTERED_FILELIST"
             mvlogger "    Hidden files are using $(bytes_to_human "$HIDDENFILES_RESERVED_SPACE")"
         fi

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -230,9 +230,7 @@ human_to_bytes() {
     numfmt --from=iec "$input"
 }
 
-# Exact byte total from du. Never parse `du -h` here: it carries two significant
-# digits, so a 58.4GiB share reads back as 62277025792 and the reserved space it
-# feeds into the threshold is always over-stated.
+# Exact bytes. `du -h` carries two significant digits and rounds up.
 du_total_bytes() {
     local out
     # du prints a total even on a partial read, so the status must be du's own
@@ -1198,7 +1196,6 @@ createFilteredFilelist() {
                                 CACHESHARERESERVEDSPACE=""
                             fi
                         fi
-                        # single du fallback for both the non-zfs pool and the zfs-folder case
                         if [ -z "$CACHESHARERESERVEDSPACE" ]; then
                             mvlogger "Calculating share usage... (can take a moment)"
                             if ! CACHESHARERESERVEDSPACE=$(du_total_bytes -s "$SHAREPATH"); then
@@ -1287,8 +1284,7 @@ createFilteredFilelist() {
         if { [ -z "$OMOVERTHRESH" ] || [ "$POOLPCTUSED" -le "$OMOVERTHRESH" ]; } && { [ "$SHAREUSECACHE" = "prefer" ] || [ "$SHAREUSECACHE" = "yes" ]; } && [ "$IGNOREHIDDENFILES" == "yes" ]; then
             mvlogger "Skipping Hidden Files. File size are taken into account in the calculation of the threshold"
             FINDSTR="$FINDSTR -not -path '*/\.*'"
-            # pipefail scoped to the subshell: a find that dies part-way still hands du
-            # a valid partial list, and the pipeline would otherwise report du's status
+            # pipefail: a part-way find still hands du a valid list
             if ! HIDDENFILES_RESERVED_SPACE=$(set -o pipefail; find "/mnt/$PRIMARYSTORAGENAME/$SHARENAME" -type f -name '.*' -print0 | du_total_bytes --files0-from=-); then
                 mvlogger "Error calculating size for hidden files in ${SHAREPATH}"
                 HIDDENFILES_RESERVED_SPACE=0

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1287,7 +1287,9 @@ createFilteredFilelist() {
         if { [ -z "$OMOVERTHRESH" ] || [ "$POOLPCTUSED" -le "$OMOVERTHRESH" ]; } && { [ "$SHAREUSECACHE" = "prefer" ] || [ "$SHAREUSECACHE" = "yes" ]; } && [ "$IGNOREHIDDENFILES" == "yes" ]; then
             mvlogger "Skipping Hidden Files. File size are taken into account in the calculation of the threshold"
             FINDSTR="$FINDSTR -not -path '*/\.*'"
-            if ! HIDDENFILES_RESERVED_SPACE=$(find "/mnt/$PRIMARYSTORAGENAME/$SHARENAME" -type f -name '.*' -print0 | du_total_bytes --files0-from=-); then
+            # pipefail scoped to the subshell: a find that dies part-way still hands du
+            # a valid partial list, and the pipeline would otherwise report du's status
+            if ! HIDDENFILES_RESERVED_SPACE=$(set -o pipefail; find "/mnt/$PRIMARYSTORAGENAME/$SHARENAME" -type f -name '.*' -print0 | du_total_bytes --files0-from=-); then
                 mvlogger "Error calculating size for hidden files in ${SHAREPATH}"
                 HIDDENFILES_RESERVED_SPACE=0
             fi
@@ -1383,7 +1385,7 @@ createFilteredFilelist() {
             mvlogger "Skipping Filetypes from List. File sizes are taken into account for the calculation of the threshold"
             for ext in $([ $overrideFlag = 1 ] && echo -n "$SKIPFILETYPES") $(echo -n "$globalSkipFileTypes"); do
                 FINDSTR="$FINDSTR -not -name '*.$ext'"
-                if SKIPPED_FILETYPES_DU="$(find "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" -type f -name "*.$ext" -print0 | du -c --block-size=1 --files0-from=- 2>/dev/null)" &&
+                if SKIPPED_FILETYPES_DU="$(set -o pipefail; find "/mnt/${PRIMARYSTORAGENAME}/${SHARENAME}" -type f -name "*.$ext" -print0 | du -c --block-size=1 --files0-from=- 2>/dev/null)" &&
                     SKIPPED_FILETYPES_RESERVED_SPACE=$(tail -n1 <<<"$SKIPPED_FILETYPES_DU" | cut -f1) && [ -n "$SKIPPED_FILETYPES_RESERVED_SPACE" ]; then
                     echo "$PRIMARYSTORAGENAME|$SECONDARYSTORAGENAME|$SHARENAME|skipped|9999999999|$PRIMARYSIZETHRESH|$POOLBYTEUSED|$SKIPPED_FILETYPES_RESERVED_SPACE|0|0|0|f|$SHAREPATH/**/*.$ext" >>"$FILTERED_FILELIST"
                     TOTAL_SKIPPED_FILETYPES_RESERVED_SPACE=$((TOTAL_SKIPPED_FILETYPES_RESERVED_SPACE + SKIPPED_FILETYPES_RESERVED_SPACE))


### PR DESCRIPTION
### Problem

`cache:only` share size (`age_mover:1188,1192`) and hidden-file size (`:1275`) were measured with `du -h` and converted back with `numfmt`. Two significant digits, rounded up, so every value lands at or above the truth:

```
truth 61239296 B  ->  "59M"  ->  61865984   (+1.02%)
truth 1394606080  ->  "1.3G" ->  1395864372
```

A user's logs show it — four `cache:only` shares, all exact GiB multiples: `62277025792` (58GiB), `24696061952` (23GiB), `37580963840` (35GiB). Their `appdata` recorded `1395864372`, which is the round trip of anything between 1.25 and 1.35GiB.

Since #165 these numbers no longer reach a gate — `remaining_bytes_used` is `POOLUSED + net_delta`, and `only`/`skipped` rows never move — so this is about what the log and the `POOLSUM` column report, not about the mover stopping early. On 2026.08.29 it did affect the decision, which is how it was found.

Second, unrelated to precision: the old form ignored `du`'s exit status. On a share with an unreadable subdirectory `du -sh` prints the readable part and exits 1, so the value was accepted anyway — measured at `41943040` against a truth of `146800640`, a silent 72% under-measurement. A path that cannot be read at all produced an empty value, which lands as `0` in the awk arithmetic.

`#163` moved the ignore-list and filetype sites to `--block-size=1`. These three kept the `-h` round trip.

### Fix

`du_total_bytes` helper using `--block-size=1`, rejecting a partial read instead of accepting the printed total. `pipefail` is scoped to the two command substitutions that pipe `find` into `du` — without it a `find` that dies part-way is masked, which fed a partial 2772721152 in testing. The two identical `du` fallbacks in the `cache:only` branch collapse into one.

### Testing

bash 5.3.15, `bash -n` clean.

| case | before | after |
| --- | --- | --- |
| share of 61239296 B | 61865984 | 61239296 |
| control: exactly 64MiB | 67108864 | 67108864 |
| hidden files, 61239296 B | 61865984 | 61239296 |
| control: no hidden files | 0 | 0 |
| partially readable share | 41943040 (truth 146800640) | rejected |
| unreadable path | empty, reads as 0 | rejected |

Controls checked against a reverted helper: the exact-size rows fail, the controls still pass.

### Left alone

`:1351` and `:1388` still spell the same `du | tail | cut` inline, and `human_to_bytes` has no callers after this. Both are follow-ups rather than part of this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved directory and file size calculations for greater accuracy, including hidden files and cache-only shares.
  - Added more reliable handling when storage information cannot be retrieved, preventing incorrect size totals.
  - Improved error detection during file and directory scanning to avoid reporting incomplete or misleading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->