### PR TITLE
Warn when the freeing threshold is above the moving threshold

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1143,6 +1143,7 @@ createFilteredFilelist() {
             fi
         elif [ "$SHAREUSECACHE" = "yes" ]; then
             mvlogger "Moving threshold: $MOVINGPCTTHRESHOLD% ($(bytes_to_human $MOVESIZETHRESH)) ; Freeing threshold: $FREEINGPCTLIMIT% ($(bytes_to_human $PRIMARYSIZETHRESH))"
+            [ $overrideFlag = 1 ] && warn_freeing_above_moving
             if [ "$REBALANCESHARES" = "yes" ] && [ -n "$UNATTENDEDSTORAGE" ]; then
                 mvlogger "Mover action: $PRIMARYSTORAGENAME->$SECONDARYSTORAGENAME (cache:yes). Rebalance shares option is selected"
                 mvlogger "=> Files detected in $UNATTENDEDSTORAGE instead of $PRIMARYSTORAGENAME or $SECONDARYSTORAGENAME. They will be rebalanced to $SECONDARYSTORAGENAME."
@@ -2297,6 +2298,14 @@ processTheMoves() {
     fi
 }
 
+# The settings pages cannot offer this combination, so it only arrives by saving a
+# lower moving threshold while the old freeing value is still selected.
+warn_freeing_above_moving() {
+    if [ "$FREEINGPCTLIMIT" -gt "$MOVINGPCTTHRESHOLD" ]; then
+        mvlogger "Warning: Freeing threshold ($FREEINGPCTLIMIT%) is above the moving threshold ($MOVINGPCTTHRESHOLD%), so no file can be moved. The settings page will show the freeing threshold as $MOVINGPCTTHRESHOLD% until it is saved again."
+    fi
+}
+
 start() {
 
     # Do not start if already running
@@ -2372,11 +2381,7 @@ start() {
         mvlogger "Warning: The mover will possibly not proceed due to the low gap between thresholds."
     fi
 
-    # The settings page cannot offer this combination, so it only arrives by saving a
-    # lower moving threshold while the old freeing value is still selected.
-    if [ "$FREEINGPCTLIMIT" -gt "$MOVINGPCTTHRESHOLD" ]; then
-        mvlogger "Warning: Freeing threshold ($FREEINGPCTLIMIT%) is above the moving threshold ($MOVINGPCTTHRESHOLD%), so no file can be moved. The settings page will show the freeing threshold as $MOVINGPCTTHRESHOLD% until it is saved again."
-    fi
+    warn_freeing_above_moving
 
     # Only start if cache enabled and present
     if ! grep -qs 'shareCacheEnabled="yes"' $UNRAIDCFGFILE && [ $(ls /boot/config/pools/*.cfg | wc -l) -lt 2 ]; then

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -2367,9 +2367,15 @@ start() {
         mvlogger "Warning: Moving thresholds are equal. No action will be taken because the thresholds do not provide a gap."
     fi
 
-    # If $MOVINGPCTTHRESHOLD - $FREEINGPCTLIMIT <= 5, log a warning message indicating that the mover will possibly not move due to the thresholds low gap beetween.
+    # If the gap is exactly 5, the smallest the settings page can offer, warn that it may not be enough.
     if [ "$MOVINGPCTTHRESHOLD" -eq "$((FREEINGPCTLIMIT + 5))" ]; then
         mvlogger "Warning: The mover will possibly not proceed due to the low gap between thresholds."
+    fi
+
+    # The settings page cannot offer this combination, so it only arrives by saving a
+    # lower moving threshold while the old freeing value is still selected.
+    if [ "$FREEINGPCTLIMIT" -gt "$MOVINGPCTTHRESHOLD" ]; then
+        mvlogger "Warning: Freeing threshold ($FREEINGPCTLIMIT%) is above the moving threshold ($MOVINGPCTTHRESHOLD%), so no file can be moved. The settings page will show the freeing threshold as $MOVINGPCTTHRESHOLD% until it is saved again."
     fi
 
     # Only start if cache enabled and present
@@ -2384,10 +2390,10 @@ start() {
         exit 5
     fi
 
-    #Delete helper files over 5 days old.
+    #Delete list files over $LISTFILESAGE days old.
     find "${LOGFOLDER}"/ca.mover.tuning/* -daystart -mtime +"$LISTFILESAGE" -name '*.list' -delete
 
-    #Delete Mover Log and txt files over 10 days old.
+    #Delete Mover Log and txt files over $LOGFILESAGE days old.
     find "${LOGFOLDER}"/ca.mover.tuning/* -daystart -mtime +"$LOGFILESAGE" \( -name '*.log' -o -name '*.txt' \) -delete
 
     #Delete Mover List files with 0 lines.


### PR DESCRIPTION
### Problem

The freeing threshold can be saved above the moving threshold, and nothing catches it.

`Mover.tuning.page:27` seeds `$f = $cfg['movingThreshold']` at page load and `:668` renders the freeing options as `for ($f=$f;$f>=0;$f-=5)` — capped at the **saved** moving value. Neither select has an `onchange`, so lowering the moving threshold from 85 to 50 and saving sends the still-selected freeing of 80 along with it. `age_mover:409-426` reads both with no cross-check.

The mover then opens the gate at 50% and tests against a target of 80% that is already met, so every run scans and moves nothing — indistinguishable from a mover that is genuinely stuck.

It is also invisible from the settings page. `mk_option` marks an option `selected` only when it matches, so with no option equal to the saved 80 the browser shows the first one, which is the moving value. The page reads `Freeing threshold: 50%` while the mover uses 80.

Neither existing warning covers it: one needs the thresholds equal, the other a gap of exactly 5, and here moving is below freeing.

### Fix

A third warning beside the other two. The log is the only place the real value shows, so the message also says what the page will display:

```
Warning: Freeing threshold (80%) is above the moving threshold (50%), so no file
can be moved. The settings page will show the freeing threshold as 50% until it
is saved again.
```

### Per share

`Share.tuning.page:36-37` and `:281` seed the per-share freeing options the same way, so a share override can save the same combination, and the start-up check only sees the global values. The warning is now a function, called once at start-up as before and once more after each overridden share's threshold line, so the log names the share that will never move.

### Testing

| moving | freeing | equal | low gap | new |
| --- | --- | --- | --- | --- |
| 50 | 80 | | | yes |
| 0 | 5 | | | yes |
| 85 | 80 | | yes | |
| 80 | 80 | yes | | |
| 90 | 35 | | | |
| 0 | 0 | | | |

Both existing warnings behave identically across all six. Checked against two deliberate breaks: `-gt` weakened to `-ge` fails the 80/80 and 0/0 rows, and deleting the warning fails the two that should fire. `bash -n` clean on 5.3.15.

### Also

Two comments corrected. `:2370` said `<= 5` where the test is `-eq` — it has been `-eq` since `1920522`, 27 minutes after `e7129c2` added it as `-le`. The two retention `find`s at `:2393,2396` had each other's day counts: "5 days" over `$LISTFILESAGE` (default 10) and "10 days" over `$LOGFILESAGE` (default 5).

Left alone: `README.md:265` says these warnings appear "when in test mode". They are not guarded by `$TESTMODE` and fire every run. That is a released changelog entry, so it seemed better not to rewrite it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup warnings when free-space thresholds are configured higher than the corresponding move thresholds.
  - Preserved the existing warning for thresholds separated by exactly five percentage points.
  - Updated settings-page behavior to display the relevant threshold warnings.

- **Documentation**
  - Clarified that list-file and mover-log retention periods are configurable rather than fixed durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
| 50 | 80, in a share override | | | yes, once for that share; silent for shares without an override |
