### PR TITLE
Compute POOLSIZE from used+avail on the df path

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1005,10 +1005,12 @@ createFilteredFilelist() {
         fi
 
         # Get the size threshold in bytes
+        # used+avail, not df's size: on btrfs those differ by the unallocated
+        # chunks, and POOLPCTUSED is measured against used+avail.
         if is_zfs_mountpoint_fstype "/mnt/$PRIMARYSTORAGENAME"; then
             POOLSIZE=$(zfs list -Hpo available,used "$PRIMARYSTORAGENAME" | awk '{print $1 + $2}')
         else
-            POOLSIZE=$(df --output=size --block-size=1 "/mnt/$PRIMARYSTORAGENAME" | tail -n 1)
+            POOLSIZE=$(df --output=used,avail --block-size=1 "/mnt/$PRIMARYSTORAGENAME" | tail -n 1 | awk '{print $1 + $2}')
         fi
 
         # Calculate primary storage size thresholds in bytes
@@ -1022,7 +1024,8 @@ createFilteredFilelist() {
         fi
 
         # Print pool info:
-        mvlogger "Primary storage: $PRIMARYSTORAGENAME - size: $(bytes_to_human $POOLSIZE) - used: $POOLPCTUSED % ($(bytes_to_human $POOLBYTEUSED))"
+        POOLFSTYPE=$(findmnt -no fstype "/mnt/$PRIMARYSTORAGENAME" | tail -n 1)
+        mvlogger "Primary storage: $PRIMARYSTORAGENAME (${POOLFSTYPE:-unknown}) - size: $(bytes_to_human $POOLSIZE) - used: $POOLPCTUSED % ($(bytes_to_human $POOLBYTEUSED))"
         mvlogger "Secondary storage: $SECONDARYSTORAGENAME"
 
         # Find unattended storage for a share when rebalancing shares


### PR DESCRIPTION
### Problem

`POOLPCTUSED` is `df --output=pcent`, which is `used/(used+avail)`. `POOLSIZE` was `df --output=size`. On btrfs those are different numbers, so the percentage the byte thresholds represent is not the percentage printed on the line above them.

Measured on a 3GB btrfs filesystem, 1.2GB written:

```
df size          3221225472
used+avail       2675539968     (the unallocated chunks are the difference)

used/size            39.34%
used/(used+avail)    47.37%     <- what df pcent and POOLPCTUSED report
```

8.66 points apart, and the gap grows as a pool empties. On a nearly full reported pool it was 2.2. So a user setting freeing to 80% gets a byte target well above the point their pool actually reads 80%, and the mover stops short of what they asked for.

`MOVESIZETHRESH` comes off the same basis, which is why the byte figure logged beside the moving threshold is not where it trips.

### Fix

Use `used+avail` on the df path, so it matches the zfs branch three lines above.

Unraid resolves this the same way in two places:

- `226b2b5` changed the zfs `POOLPCTUSED` from `zpool get capacity` to `zfs list available,used`, specifically to match the `POOLSIZE` line below it
- `DashStats.page:85` has an explicit btrfs case using `fsFree+fsUsed` rather than `fsSize` for the percentage the dashboard shows

`POOLPCTUSED` is left alone, so **the moving threshold fires exactly when it does now**. Only the byte targets move, onto the basis the percentage already implied.

### Testing

| filesystem | df size | used+avail | delta |
| --- | --- | --- | --- |
| btrfs | 3221225472 | 2675539968 | 545685504 |
| xfs | 3154116608 | 3154116608 | 0 |

Both on real loopback filesystems. xfs is a no-op, and zfs does not reach this branch. After the change the byte basis sits 0.63 points from the reported percentage, which is `df` rounding its own percentage up.

### Also

The plugin never logged the pool filesystem — `is_zfs_mountpoint_fstype` reads it and returns only a boolean — so a log posted without the diagnostics zip gave no way to tell which branch ran. The `Primary storage:` line now names it.

Worth noting separately: `is_zfs_mountpoint_fstype` is called three times per share and runs `findmnt` each time. Reading it once per pool would fold that plus this new call into one, but that touches more than this change needs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pool size calculations for non-ZFS filesystems by using combined used and available space, providing more accurate capacity reporting.
  - Enhanced pool logging to show the detected filesystem type, including an `unknown` value when the type cannot be determined. This makes pool status information clearer and helps with troubleshooting across different filesystem configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->