### PR TITLE
Fix the Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       suffix:
-        description: "Version suffix (optional: a, b, c)"
+        description: "Version suffix for another build on the same day (optional): a letter such as a, or a dot-number such as .1 or .2004"
         required: false
         default: ""
       publish:
@@ -33,7 +33,7 @@ jobs:
       env:
         SUFFIX: ${{ inputs.suffix }}
       run: |
-        [[ "$SUFFIX" =~ ^[abc]?$ ]] || { echo "suffix must be empty, a, b or c"; exit 1; }
+        [[ "$SUFFIX" =~ ^([a-z]|\.[a-z0-9]+)?$ ]] || { echo "suffix must be empty, a letter (a), or a dot-number (.1)"; exit 1; }
 
     - name: Run pkg_build.sh
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,17 @@ on:
         description: "Version suffix (optional: a, b, c)"
         required: false
         default: ""
+      publish:
+        description: "Commit the package, manifest and changelog to this branch"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+
+env:
+  PLUGIN_NAME: ca.mover.tuning
 
 jobs:
   build:
@@ -14,75 +25,59 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        path: ca.mover.tuning
 
-    - name: Install build tools
+    - name: Check version suffix
+      env:
+        SUFFIX: ${{ inputs.suffix }}
       run: |
-        sudo apt update
-        sudo apt install -y rsync makepkg
-
-    - name: Prepare directories
-      run: |
-        export PLUGIN_NAME="ca.mover.tuning"
-        export COMPILE_DIR="$GITHUB_WORKSPACE/build"
-        mkdir -p "$COMPILE_DIR"
-
-        echo "Syncing plugin source to build directory..."
-        rsync -a --exclude='.git/' --exclude='.vscode/' "$GITHUB_WORKSPACE/$PLUGIN_NAME/" "$COMPILE_DIR/$PLUGIN_NAME/"
+        [[ "$SUFFIX" =~ ^[abc]?$ ]] || { echo "suffix must be empty, a, b or c"; exit 1; }
 
     - name: Run pkg_build.sh
+      env:
+        SUFFIX: ${{ inputs.suffix }}
       run: |
-        export PLUGIN_NAME="ca.mover.tuning"
-        export COMPILE_DIR="$GITHUB_WORKSPACE/build"
-        export DATE_VERSION="${{ github.event.inputs.suffix }}"
-
-        cd "$COMPILE_DIR/$PLUGIN_NAME/source/$PLUGIN_NAME"
-        bash pkg_build.sh "$COMPILE_DIR" "$DATE_VERSION"
+        cd "$PLUGIN_NAME/source/$PLUGIN_NAME"
+        bash pkg_build.sh "$GITHUB_WORKSPACE" "$SUFFIX"
 
     - name: Validate build
       id: validate
       run: |
-        export PLUGIN_NAME="ca.mover.tuning"
-        export COMPILE_DIR="$GITHUB_WORKSPACE/build"
+        cfg="$PLUGIN_NAME/source/$PLUGIN_NAME/usr/local/emhttp/plugins/$PLUGIN_NAME/default.cfg"
+        version=$(sed -n 's/^version="\([^"]*\)"/\1/p' "$cfg")
+        package="$PLUGIN_NAME-$version-x86_64-1.txz"
+        test -s "$PLUGIN_NAME/archive/$package"
+        md5=$(md5sum "$PLUGIN_NAME/archive/$package" | cut -d' ' -f1)
+        grep -Fq "\"$md5\"" "$PLUGIN_NAME/plugins/$PLUGIN_NAME.plg"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "package=$package" >> "$GITHUB_OUTPUT"
 
-        built_package=$(ls -t "$COMPILE_DIR/$PLUGIN_NAME/archive" | head -1)
-        echo "package=$built_package" >> $GITHUB_OUTPUT
-
-        if [ -z "$built_package" ]; then
-          echo "No package found"
-          exit 1
-        fi
-
-        FILE_TIMESTAMP=$(date -r "$COMPILE_DIR/$PLUGIN_NAME/archive/$built_package" +%s)
-        CURRENT_TIMESTAMP=$(date +%s)
-        TIME_DIFF=$((CURRENT_TIMESTAMP - FILE_TIMESTAMP))
-
-        if [ $TIME_DIFF -le 300 ]; then
-          echo "Plugin compiled successfully"
-        else
-          echo "Plugin compilation failed: file older than 5 minutes"
-          exit 1
-        fi
-
-    - name: Copy updated files back to repo
+    - name: Write release info
+      env:
+        VERSION: ${{ steps.validate.outputs.version }}
+        PUBLISH: ${{ inputs.publish }}
       run: |
-        export PLUGIN_NAME="ca.mover.tuning"
-        export COMPILE_DIR="$GITHUB_WORKSPACE/build"
-
-        cp -a "$COMPILE_DIR/$PLUGIN_NAME/README.md" "$GITHUB_WORKSPACE/$PLUGIN_NAME/"
-        cp -a "$COMPILE_DIR/$PLUGIN_NAME/archive/" "$GITHUB_WORKSPACE/$PLUGIN_NAME/"
-        cp -a "$COMPILE_DIR/$PLUGIN_NAME/plugins/" "$GITHUB_WORKSPACE/$PLUGIN_NAME/"
-        cp -a "$COMPILE_DIR/$PLUGIN_NAME/source/$PLUGIN_NAME/usr/local/emhttp/plugins/$PLUGIN_NAME/default.cfg" \
-              "$GITHUB_WORKSPACE/$PLUGIN_NAME/source/$PLUGIN_NAME/usr/local/emhttp/plugins/$PLUGIN_NAME/default.cfg"
-
-    - name: Commit updated files
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: "Auto-build: ${{ steps.validate.outputs.package }}"
-        branch: main
+        jq -n --arg tag "$VERSION" --arg name "Mover Tuning $VERSION" --arg new "$PUBLISH" \
+          '{release_tag: $tag, release_name: $name, new_release: $new}' > release_info.json
 
     - name: Upload built package artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: mover-tuning-package
-        path: build/ca.mover.tuning/archive/*.txz
+        path: ca.mover.tuning/archive/${{ steps.validate.outputs.package }}
+
+    - name: Upload release info
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: release_info
+        path: release_info.json
+
+    - name: Commit updated files
+      if: ${{ inputs.publish }}
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+      with:
+        repository: ca.mover.tuning
+        commit_message: "Auto-build: ${{ steps.validate.outputs.package }}"
+        file_pattern: README.md archive/ plugins/ source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/default.cfg

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -8,7 +8,7 @@ on:
   issues:
     types: [opened, closed, reopened]
   workflow_run:
-    workflows: ["Auto Build & Release Mover Tuning Package"]
+    workflows: ["Build Mover Tuning Plugin"]
     types: [completed]
   workflow_dispatch:
 
@@ -24,8 +24,10 @@ jobs:
       # 1. Download release info artifact (workflow_run only)
       # ---------------------------------------------------------
       - name: Download release info artifact
+        id: release_artifact
         if: ${{ github.event_name == 'workflow_run' }}
-        uses: actions/download-artifact@v8
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: release_info
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,16 +37,18 @@ jobs:
       # 2. Parse release info JSON
       # ---------------------------------------------------------
       - name: Read release info
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_run' && steps.release_artifact.outcome == 'success' }}
         id: release_info
         run: |
           RELEASE_TAG=$(jq -r '.release_tag' release_info.json)
           RELEASE_NAME=$(jq -r '.release_name' release_info.json)
           NEW_RELEASE=$(jq -r '.new_release' release_info.json)
 
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> ${GITHUB_ENV}
-          echo "RELEASE_NAME=${RELEASE_NAME}" >> ${GITHUB_ENV}
-          echo "NEW_RELEASE=${NEW_RELEASE}" >> ${GITHUB_ENV}
+          {
+            echo "RELEASE_TAG=${RELEASE_TAG}"
+            echo "RELEASE_NAME=${RELEASE_NAME}"
+            echo "NEW_RELEASE=${NEW_RELEASE}"
+          } >> "${GITHUB_ENV}"
 
       # ---------------------------------------------------------
       # 3. Build & send Discord embed
@@ -90,15 +94,15 @@ jobs:
           # Guard: Webhook must exist
           # -----------------------------------------------------
           if [ -z "${WEBHOOK}" ]; then
-            echo "ERROR: Discord webhook is empty"
-            exit 1
+            echo "::warning::DISCORD_WEBHOOK is not set, skipping notification"
+            exit 0
           fi
 
           # -----------------------------------------------------
-          # Truncate bodies to avoid Discord 4096 limit
+          # Truncate bodies to 300 characters (not bytes)
           # -----------------------------------------------------
           truncate() {
-            echo "$1" | head -c 300
+            printf '%s' "$1" | python3 -c 'import sys; sys.stdout.write(sys.stdin.read()[:300])'
           }
 
           # -----------------------------------------------------
@@ -194,11 +198,11 @@ jobs:
 
             START=$(date -d "${WORKFLOW_STARTED}" +%s)
             END=$(date -d "${WORKFLOW_FINISHED}" +%s)
-            SECONDS=$((END - START))
+            ELAPSED=$((END - START))
 
-            H=$((SECONDS / 3600))
-            M=$(((SECONDS % 3600) / 60))
-            S=$((SECONDS % 60))
+            H=$((ELAPSED / 3600))
+            M=$(((ELAPSED % 3600) / 60))
+            S=$((ELAPSED % 60))
 
             if [ ${H} -gt 0 ]; then
               DURATION="${H}h ${M}m ${S}s"
@@ -272,6 +276,8 @@ jobs:
           # -----------------------------------------------------
           # Send to Discord
           # -----------------------------------------------------
-          curl -H "Content-Type: application/json" \
+          curl --fail-with-body --silent --show-error \
+               --connect-timeout 10 --max-time 30 \
+               -H "Content-Type: application/json" \
                -d "${JSON}" \
                "${WEBHOOK}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@ Desktop.ini
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 
-# Updates by pr in new version
-.updates.txt
-
 # VS Code Settings
 .vscode
 

--- a/source/ca.mover.tuning/pkg_build.sh
+++ b/source/ca.mover.tuning/pkg_build.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
+set -euo pipefail
 
 # Get the directory of the script
-DIR="$(dirname "$(readlink -f ${BASH_SOURCE[0]})")"
+DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # Set the temporary directory and plugin name
 tmpdir=/tmp/tmp.$(( RANDOM * 19318203981230 + 40 ))
 plugin=$(basename "${DIR}")
 archive="$(dirname "$(dirname "${DIR}")")/archive"
 # $2 is argument addition to date (a,b,c)
-version=$(date +"%Y.%m.%d")$2
+version=$(date +"%Y.%m.%d")${2:-}
 # $1 Path to the plugin directory
 config_file="$1/$plugin/plugins/$plugin.plg"
 readme_file="$1/$plugin/README.md"
@@ -17,20 +18,22 @@ default_config_file="$1/$plugin/source/$plugin/usr/local/emhttp/plugins/$plugin/
 mkdir -p $tmpdir
 
 # Get the content from .update file
-update_content="$(dirname $(dirname "$DIR"))/.updates.txt"
+update_content="$(dirname "$(dirname "$DIR")")/.updates.txt"
+[ -s "$update_content" ] || { echo "Missing release notes: $update_content" >&2; exit 1; }
 
 # Step 0: Change to current version in $default_config_file
 sed -i "s/version=.*/version=\"$version\"/" "$default_config_file"
 
-cp --parents -f $(find . -type f ! \( -iname "pkg_build.sh" -o -iname "sftp-config.json"  \) ) $tmpdir/
+find . -type f ! \( -iname "pkg_build.sh" -o -iname "sftp-config.json" \) -exec cp --parents -f -t "$tmpdir/" {} +
 
 cd $tmpdir
 
-# Build the package using makepkg
-makepkg -l y -c y ${archive}/${plugin}-${version}-x86_64-1.txz
+# Same layout as `makepkg -l y -c y` (root-owned, 755 dirs), without needing Slackware
+find . -type d -exec chmod 755 {} +
+find ./ | LC_COLLATE=C sort | sed '2,$s,^\./,,' | tar --no-recursion --owner=0 --group=0 -T - -cJf "${archive}/${plugin}-${version}-x86_64-1.txz"
 
 # Calculate the MD5 hash of the package
-package_md5=$(md5sum ${archive}/${plugin}-${version}-x86_64-1.txz | awk '{print $1}')
+package_md5=$(md5sum "${archive}/${plugin}-${version}-x86_64-1.txz" | awk '{print $1}')
 
 echo "Version: $version"
 echo "MD5: $package_md5"


### PR DESCRIPTION
Ran the build workflow step by step and compared its package with a real `makepkg` build. Five things stopped it from working, on top of what CodeRabbit flagged.

**Fixed**
- Checkout puts the repo in the root, but every step looked in a `ca.mover.tuning` folder that did not exist. It now checks out into that folder.
- It committed to `main`, which this repo does not have. It now commits to the branch you ran it on.
- `makepkg` on the GitHub runner is the Arch Linux one and cannot build a txz. The script now packs the txz with `tar` the same way Slackware's `makepkg` does. The output is identical, and it still works on Unraid.
- The success check only looked at file times, which are always fresh on a runner, so a failed build would have passed and committed a plg with an empty md5. It now checks the exact package and that its md5 is in the plg.
- `.updates.txt` was git-ignored, so the runner never had the changelog text. It is tracked now: write the notes, commit them, then run the build.

**Also**
- New `publish` switch, off by default: a plain run only builds and uploads the package, so you can test without touching master.
- The Discord workflow now matches the build workflow's name and gets a `release_info` file from it, so the release message will fire. Its curl fails on errors and has timeouts, and a fork PR without the webhook secret no longer shows a red X.
- Actions pinned to commits, permissions declared, suffix input checked, as CodeRabbit asked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release builds now provide clearer package versioning and release metadata.
  - Published builds can include the packaged plugin, manifest, README, and configuration files.
  - Release information is available as a downloadable build artifact.

- **Bug Fixes**
  - Package validation now confirms the expected versioned archive and matching manifest checksum.
  - Release notifications handle missing notification configuration and failed artifact downloads more gracefully.
  - Packaging now produces consistent file permissions and ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->