### PR TITLE
Stop restoring mover.old on Unraid 7.2.1 and newer

### DIFF
--- a/plugins/ca.mover.tuning.plg
+++ b/plugins/ca.mover.tuning.plg
@@ -653,18 +653,6 @@ if version_ge "$UNRAID_VERSION" "7.2.1"; then
         echo "Migrated cron entry: age_mover → mover"
     fi
 
-    # Restore original mover if both current and backup exist
-    if [[ -f /usr/local/sbin/mover &amp;&amp; -f /usr/local/sbin/mover.old ]]; then
-        echo "Restoring original /usr/local/sbin/mover from backup"
-        mv /usr/local/sbin/mover.old /usr/local/sbin/mover
-    fi
-
-    # Same for /usr/local/bin/mover
-    if [[ -f /usr/local/bin/mover &amp;&amp; -f /usr/local/bin/mover.old ]]; then
-        echo "Restoring original /usr/local/bin/mover from backup"
-        mv /usr/local/bin/mover.old /usr/local/bin/mover
-    fi
-
 else
     echo "Unraid version below 7.2.1 — performing mover script backup."
 
@@ -754,13 +742,18 @@ else
   exit 1
 fi
 
-# Restore original mover binaries if backups exist
-if [[ -e /usr/local/sbin/mover.old ]]; then
-  mv -f /usr/local/sbin/mover.old /usr/local/sbin/mover
-fi
-
-if [[ -e /usr/local/bin/mover.old ]]; then
-  mv -f /usr/local/bin/mover.old /usr/local/bin/mover
+# Restore the mover this plugin backed up below Unraid 7.2.1 only; 7.4 ships its own mover.old
+UNRAID_VERSION=$(grep '^version=' /etc/unraid-version | cut -d'"' -f2)
+version_ge() {
+  [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+if ! version_ge "$UNRAID_VERSION" "7.2.1"; then
+  if [[ -e /usr/local/sbin/mover.old ]]; then
+    mv -f /usr/local/sbin/mover.old /usr/local/sbin/mover
+  fi
+  if [[ -e /usr/local/bin/mover.old ]]; then
+    mv -f /usr/local/bin/mover.old /usr/local/bin/mover
+  fi
 fi
 
 # Restore original mover cron if backup exists


### PR DESCRIPTION
Unraid 7.4.0-beta.2 ships `/usr/local/sbin/mover.old` beside the rewritten mover (unraid/webgui#1042, present from tag 7.4.0-beta.1.1). The install script's 7.2.1+ branch and the remove script move any `mover.old` over `mover`, so the plugin puts the old mover back on every boot and Mover Progress never works.

The plugin only creates `mover.old` below 7.2.1, and `/usr/local/sbin` is rebuilt from bzroot at boot, so the 7.2.1+ restore in the install script can never act on a backup the plugin made. Removed it. The remove script now restores only below 7.2.1, using the same `version_ge` as the install script.

Tested on 7.3.2 (bash 5.3): `bash -n` on all three bash blocks; the remove-script restore against a fixture `mover.old` for 7.1.4, 7.2.0, 7.2.1-rc.1, 7.2.1, 7.3.2 and 7.4.0-beta.2 moves it only on 7.1.4 and 7.2.0 (before: all six). Not yet run on a 7.4 install, hence draft.

Part of #172.

**The issue raised for tracking 7.4 release and this PR is a work in progress until the beta or 7.4 stable is released and tested.**