### PR TITLE
Fix run-state handling in share_mover and updateCron.php

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
@@ -132,7 +132,9 @@ if ! mountpoint -q /mnt/user0 && [ $(ls /boot/config/pools/*.cfg | wc -l) -lt 2 
     exit 5
 fi
 
-echo $$ >/var/run/mover.pid
+echo $$ >"$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+trap 'exit 143' HUP INT TERM
 
 shopt -s nullglob
 
@@ -153,7 +155,7 @@ if grep -qs 'shareUseCache="yes\|shareUseCache="prefer"' "$SHARECFG"; then
         # Do not process this pool if path does not exist
         mvlogger "/mnt/$PRIMARYSTORAGENAME does not exist. Is the pool still used? Consider removing $SHARECFG if not."
         mvlogger "=> Skipping"
-        exit # Move to the next iteration of the loop
+        exit
     fi
 
     # Determine secondary storage
@@ -230,11 +232,6 @@ if grep -qs 'shareUseCache="yes\|shareUseCache="prefer"' "$SHARECFG"; then
 
     fi
 fi
-
-mvlogger "Cleaning lock file"
-for file in $PIDFILE; do
-    [[ -e "$file" ]] && rm -f "$file"
-done
 
 mvlogger "$(titleLine 'WE ARE DONE !' '*')"
 [ $LOGLEVEL = 0 ] && echo "Mover tuning plugin done!"

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
@@ -132,9 +132,13 @@ if ! mountpoint -q /mnt/user0 && [ $(ls /boot/config/pools/*.cfg | wc -l) -lt 2 
     exit 5
 fi
 
-echo $$ >"$PIDFILE"
-trap 'rm -f "$PIDFILE"' EXIT
+# Remove the pid file only while it still names this run, so overlapping runs cannot delete each other's
+pid_cleanup() {
+    [ "$(cat "$PIDFILE" 2>/dev/null)" = "$$" ] && rm -f "$PIDFILE"
+}
+trap pid_cleanup EXIT
 trap 'exit 143' HUP INT TERM
+echo $$ >"$PIDFILE"
 
 shopt -s nullglob
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
@@ -54,7 +54,7 @@ function cron_field_ok($field, $min, $max, $names)
 		if (preg_match('/^(\*|([a-z0-9]+)(?:-([a-z0-9]+))?)(?:\/([0-9]+))?\z/i', $item, $m) !== 1) {
 			return false;
 		}
-		if (isset($m[4]) && (int)$m[4] < 1) {
+		if (isset($m[4]) === true && (int)$m[4] < 1) {
 			return false;
 		}
 		if ($m[1] === '*') {
@@ -66,7 +66,7 @@ function cron_field_ok($field, $min, $max, $names)
 			}
 			// names count from $min, so jan is 1 and sun is 0
 			$index = array_search(strtolower($value), $names, true);
-			$n = is_numeric($value) ? (int)$value : ($index === false ? -1 : $index + $min);
+			$n = ctype_digit($value) === true ? (int)$value : ($index === false ? -1 : $index + $min);
 			if ($n < $min || $n > $max) {
 				return false;
 			}

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
@@ -24,6 +24,12 @@ function logger($string)
 	}
 }
 
+// A form field as a string; anything else, such as an array, counts as empty
+function post_string($key)
+{
+	return isset($_POST[$key]) === true && is_string($_POST[$key]) === true ? $_POST[$key] : '';
+}
+
 // Five fields of * / n / n-m lists with an optional /step, each within its range; anything else would land in root's crontab.
 // dcron's @hourly..@yearly forms need an ID= job name the writers below do not add, so they are not accepted.
 function valid_cron($cron)
@@ -82,6 +88,10 @@ function make_unraid_cron()
 
 	if (!empty($vars['shareMoverSchedule'])) {
 		$moverCron = trim($vars['shareMoverSchedule']);
+		if (valid_cron($moverCron) === false) {
+			logger("Error: Invalid Unraid mover schedule: " . preg_replace('/[^[:print:]]/', '?', $moverCron));
+			return;
+		}
 		$cronMoverFile = "# Generated mover schedule:\n" . $moverCron . " /usr/local/sbin/mover start |& logger -t move\n\n";
 		if (file_put_contents("/boot/config/plugins/dynamix/mover.cron", $cronMoverFile) === false) {
 			logger("Error: Failed to write mover.cron file.");
@@ -93,7 +103,7 @@ function make_unraid_cron()
 function make_tune_cron()
 {
 	global $cfg_moverTuneCron;
-	$tuneCron = isset($_POST['tune_cron']) ? trim($_POST['tune_cron']) : $cfg_moverTuneCron;
+	$tuneCron = isset($_POST['tune_cron']) === true ? trim(post_string('tune_cron')) : $cfg_moverTuneCron;
 	if (empty($tuneCron)) {
 		logger("Error: No cron schedule provided for Mover Tuning move.");
 		return; // Nothing to write
@@ -114,7 +124,7 @@ function make_cron()
 	global $vars;
 	$version = $vars['version'] ?? '0.0.0';
 	$mover = version_compare($version, '7.2.1', '<') ? '/usr/local/sbin/mover.old' : '/usr/local/sbin/mover';
-	$cron = isset($_POST['cron']) ? trim($_POST['cron']) : '';
+	$cron = trim(post_string('cron'));
 	if (empty($cron)) {
 		logger("Error: No cron schedule provided for forced move.");
 		return;
@@ -190,7 +200,7 @@ if ($cfg_moverDisabled != $_POST["ismoverDisabled"]) {
 
 // Handle Mover Tuning custom cron schedule, unless this request disables Mover Tuning
 if (version_compare($vars['version'], '7.2.1', '>=') === true && ($_POST['ismoverDisabled'] ?? '') !== 'yes') {
-	$postTuneCron = isset($_POST['tune_cron']) ? $_POST['tune_cron'] : '';
+	$postTuneCron = post_string('tune_cron');
 	if ($cfg_moverTuneCron !== $postTuneCron) {
 		if (trim($postTuneCron) !== "") {
 			make_tune_cron();

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
@@ -23,6 +23,12 @@ function logger($string)
 	}
 }
 
+// Five fields only; a newline or stray token here would land in root's crontab
+function valid_cron($cron)
+{
+	return preg_match('/^[A-Za-z0-9*,\/-]+(?:[ \t]+[A-Za-z0-9*,\/-]+){4}\z/', $cron) === 1;
+}
+
 // Unraid Mover cron for unraid v7.2.1+
 function make_unraid_cron()
 {
@@ -46,6 +52,10 @@ function make_tune_cron()
 		logger("Error: No cron schedule provided for Mover Tuning move.");
 		return; // Nothing to write
 	}
+	if (valid_cron($tuneCron) === false) {
+		logger("Error: Invalid cron schedule for Mover Tuning move: $tuneCron");
+		return;
+	}
 	$cronTuneFile = "# Generated schedule for Mover Tuning move:\n" . $tuneCron . " /usr/local/emhttp/plugins/ca.mover.tuning/mover start |& logger -t move\n\n";
 	if (file_put_contents("/boot/config/plugins/ca.mover.tuning/mover.tuning.cron", $cronTuneFile) === false) {
 		logger("Error: Failed to write mover.tuning.cron file.");
@@ -61,6 +71,10 @@ function make_cron()
 	$cron = isset($_POST['cron']) ? trim($_POST['cron']) : '';
 	if (empty($cron)) {
 		logger("Error: No cron schedule provided for forced move.");
+		return;
+	}
+	if (valid_cron($cron) === false) {
+		logger("Error: Invalid cron schedule for forced move: $cron");
 		return;
 	}
 	$cronFile = "# Generated schedule for forced move:\n{$cron} {$mover} start |& logger -t move\n\n";
@@ -128,8 +142,8 @@ if ($cfg_moverDisabled != $_POST["ismoverDisabled"]) {
 	}
 }
 
-// Handle Mover Tuning custom cron schedule
-if (version_compare($vars['version'], '7.2.1', '>=')) {
+// Handle Mover Tuning custom cron schedule, unless this request disables Mover Tuning
+if (version_compare($vars['version'], '7.2.1', '>=') === true && ($_POST['ismoverDisabled'] ?? '') !== 'yes') {
 	$postTuneCron = isset($_POST['tune_cron']) ? $_POST['tune_cron'] : '';
 	if ($cfg_moverTuneCron !== $postTuneCron) {
 		if (trim($postTuneCron) !== "") {

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
@@ -14,6 +14,7 @@ $cfg_moverDisabled = $cfg['moverDisabled'];
 // Get Mover Tuning cron time (normalized)
 $cfg_moverTuneCron = trim($cfg['moverTuneCron'] ?? $vars['shareMoverSchedule'] ?? '');
 
+// Write a message to syslog under the "move" tag when plugin logging is enabled
 function logger($string)
 {
 	global $cfg;
@@ -46,6 +47,7 @@ function valid_cron($cron)
 	return true;
 }
 
+// One cron field: a comma list of * / n / n-m, each with an optional /step; numbers within min..max, names looked up in $names
 function cron_field_ok($field, $min, $max, $names)
 {
 	foreach (explode(',', $field) as $item) {

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
@@ -23,10 +23,56 @@ function logger($string)
 	}
 }
 
-// Five fields only; a newline or stray token here would land in root's crontab
+// One @keyword, or five fields of * / n / n-m lists with an optional /step, each within its range; anything else would land in root's crontab
 function valid_cron($cron)
 {
-	return preg_match('/^[A-Za-z0-9*,\/-]+(?:[ \t]+[A-Za-z0-9*,\/-]+){4}\z/', $cron) === 1;
+	if (preg_match('/^@(reboot|hourly|daily|weekly|monthly|yearly)\z/', $cron) === 1) {
+		return true;
+	}
+	$fields = preg_split('/[ \t]+/', $cron);
+	if (count($fields) !== 5) {
+		return false;
+	}
+	$limits = [
+		[0, 59, []],
+		[0, 23, []],
+		[1, 31, []],
+		[1, 12, ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']],
+		[0, 7, ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']],
+	];
+	foreach ($fields as $i => $field) {
+		if (cron_field_ok($field, $limits[$i][0], $limits[$i][1], $limits[$i][2]) === false) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function cron_field_ok($field, $min, $max, $names)
+{
+	foreach (explode(',', $field) as $item) {
+		if (preg_match('/^(\*|([a-z0-9]+)(?:-([a-z0-9]+))?)(?:\/([0-9]+))?\z/i', $item, $m) !== 1) {
+			return false;
+		}
+		if (isset($m[4]) && (int)$m[4] < 1) {
+			return false;
+		}
+		if ($m[1] === '*') {
+			continue;
+		}
+		foreach ([$m[2], $m[3] ?? ''] as $value) {
+			if ($value === '') {
+				continue;
+			}
+			// names count from $min, so jan is 1 and sun is 0
+			$index = array_search(strtolower($value), $names, true);
+			$n = is_numeric($value) ? (int)$value : ($index === false ? -1 : $index + $min);
+			if ($n < $min || $n > $max) {
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 // Unraid Mover cron for unraid v7.2.1+
@@ -53,7 +99,7 @@ function make_tune_cron()
 		return; // Nothing to write
 	}
 	if (valid_cron($tuneCron) === false) {
-		logger("Error: Invalid cron schedule for Mover Tuning move: $tuneCron");
+		logger("Error: Invalid cron schedule for Mover Tuning move: " . preg_replace('/[^[:print:]]/', '?', $tuneCron));
 		return;
 	}
 	$cronTuneFile = "# Generated schedule for Mover Tuning move:\n" . $tuneCron . " /usr/local/emhttp/plugins/ca.mover.tuning/mover start |& logger -t move\n\n";
@@ -74,7 +120,7 @@ function make_cron()
 		return;
 	}
 	if (valid_cron($cron) === false) {
-		logger("Error: Invalid cron schedule for forced move: $cron");
+		logger("Error: Invalid cron schedule for forced move: " . preg_replace('/[^[:print:]]/', '?', $cron));
 		return;
 	}
 	$cronFile = "# Generated schedule for forced move:\n{$cron} {$mover} start |& logger -t move\n\n";

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/updateCron.php
@@ -23,12 +23,10 @@ function logger($string)
 	}
 }
 
-// One @keyword, or five fields of * / n / n-m lists with an optional /step, each within its range; anything else would land in root's crontab
+// Five fields of * / n / n-m lists with an optional /step, each within its range; anything else would land in root's crontab.
+// dcron's @hourly..@yearly forms need an ID= job name the writers below do not add, so they are not accepted.
 function valid_cron($cron)
 {
-	if (preg_match('/^@(reboot|hourly|daily|weekly|monthly|yearly)\z/', $cron) === 1) {
-		return true;
-	}
 	$fields = preg_split('/[ \t]+/', $cron);
 	if (count($fields) !== 5) {
 		return false;


### PR DESCRIPTION
**share_mover** removed its pid file only on the normal path. A share whose pool path no longer exists exits at the skip with `/var/run/mover.pid` in place, and `mover stop` (TERM) leaves it too. `mover.php` refuses to start while that file exists, so every later scheduled or button run is refused until reboot. The pid file is now removed by an EXIT trap, with HUP/INT/TERM mapped to an exit, the same pattern as the stock mover.

**updateCron.php**: a request that disables Mover Tuning and changes the schedule removed the cron file and then recreated it; that block now runs only when the request keeps Mover Tuning enabled. Both schedule fields are checked for five plain fields before writing: a newline in the field added a second root cron line, and a typo produced an unparseable crontab. A rejected schedule is logged, as an empty one already was.

Tested on 7.3.2 from copies with the pid, config and cron paths pointed at fixtures, old beside new:

- missing pool path: pid file left before, removed now; normal share in test mode: clean in both; TERM after 1 s: rc 143 in both, pid file left before, removed now
- disable + schedule change in one request: file recreated before, absent now; schedule change while enabled: written in both
- `0 0 * * *` followed by a newline and a second line: two cron lines before, rejected now; `every day`: rejected; `0 3 * * mon-fri`: accepted; forced schedule with a newline: rejected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of process tracking files when tasks finish or are interrupted.
  - Improved handling of task termination signals to ensure processes exit cleanly.
  - Added validation for custom cron schedules, preventing invalid schedules from being applied and recording sanitized errors.
  - Standard five-field schedules now support numeric values, ranges, steps, and common month and weekday names.
  - Invalid schedules for Mover, Mover Tuning, and forced moves are no longer written.
  - Custom schedule processing now stops when Mover Tuning is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->