### PR TITLE
Reset to global settings before applying a share override

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -948,15 +948,15 @@ createFilteredFilelist() {
         mvlogger "$(titleLine "Processing [$SHARENAME] share" '-')"
 
         #Check to see if this share has a mover settings override, if yes set overrideFlag and change settings
-        if [ -f "${MOVERTUNING_OVERRIDE_CFGFOLDER}/${SHARENAME}.cfg" ]; then
-            SHARETUNINGFILE="${MOVERTUNING_OVERRIDE_CFGFOLDER}/${SHARENAME}.cfg"
-            if grep -qs 'moverOverride="yes"' "$SHARETUNINGFILE"; then
-                overrideFlag=1
-                mvlogger "Settings override:"
-                mvlogger "------------------"
-                getMoverSettings "$SHARETUNINGFILE"
-                mvlogger "------------------------------------------------------------------------"
-            fi
+        SHARETUNINGFILE="${MOVERTUNING_OVERRIDE_CFGFOLDER}/${SHARENAME}.cfg"
+        if grep -qs 'moverOverride="yes"' "$SHARETUNINGFILE"; then
+            # Start from the global settings so the previous share's override cannot carry over
+            [ $overrideFlag = 1 ] && getMoverSettings "$MOVERTUNINGCFGFILE"
+            overrideFlag=1
+            mvlogger "Settings override:"
+            mvlogger "------------------"
+            getMoverSettings "$SHARETUNINGFILE"
+            mvlogger "------------------------------------------------------------------------"
         elif [ $overrideFlag = 1 ]; then
             #else if overrideFLag set from previous loop then restore global settings
             overrideFlag=0


### PR DESCRIPTION
`age_mover` restored the global settings only when the next share had no override file. A file switched to `moverOverride="no"` matched neither branch, so that share ran with the previous share's filters and thresholds, and a second overridden share inherited whatever its own file left at "No" (size, sparseness, skip types, move-all). Any share whose Mover Tuning tab was ever saved with override = No has such a file.

The global config is now reloaded before an override is applied when the previous share was overridden, and a switched-off file falls into the existing restore branch like a missing one.

Tested on 7.3.2 with `getMoverSettings` and the per-share block extracted verbatim, fixture configs only. Global: all filters off, 35/25. A: age 30, size 500, sparseness 5, types .tmp/.part, hidden, move-all 90, ctime, 70/50.

| sequence | before | after |
|---|---|---|
| A, then no file | globals | globals |
| A, then file with override No | all of A | globals |
| A, then override on with every filter No | A's size, sparseness, types, move-all | globals |
| A, then a second override (age 7, size 100, atime, 60/40) | its own values plus A's sparseness, types, move-all | its own values only |

A "No" inside an override now inherits the global value for size, sparseness, file list, file types and move-all, and means off for age, hidden files, ctime, atime and sync, which is how `getMoverSettings` already reads them. Whether "No" should mean off for all of them is a separate decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed share-specific tuning overrides so settings from one share no longer carry over to another.
  - Improved detection and loading of active share override configurations.
  - Ensured global settings are restored before applying a new share’s override settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->