### PR TITLE
Capture mover state in the debug package and name the launcher for detached web runs

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -111,14 +111,21 @@ move() {
     find "$1" -depth -type d 2>/dev/null | /usr/libexec/unraid/move $DEBUGGING
 }
 
-# Detect execution method by finding the top-level root ancestor process
-# (crond = Cron, ttyd = CLI, php-fpm = Web Button)
+# Detect execution method: MOVER_RUN_METHOD when the launcher names it, else the
+# top-level ancestor process (crond = Cron, ttyd/sshd = CLI, php-fpm = Web Button)
 UPPER_PROC=""
 curr_pid=$$
 IS_CRON=0
 RUN_METHOD=""
 
 detect_run_method() {
+    # A detached web launch reparents to PID 1, so the walk below never sees php-fpm.
+    if [ -n "${MOVER_RUN_METHOD:-}" ]; then
+        RUN_METHOD="$MOVER_RUN_METHOD"
+        [ "$RUN_METHOD" = "cron" ] && IS_CRON=1
+        return
+    fi
+
     while [[ "$curr_pid" =~ ^[0-9]+$ ]] && [ "$curr_pid" -gt 1 ]; do
         if [ -r "/proc/$curr_pid/status" ]; then
             unset comm ppid
@@ -148,7 +155,7 @@ detect_run_method() {
         RUN_METHOD="cron"
         IS_CRON=1
         ;;
-    ttyd) RUN_METHOD="cli" ;;
+    ttyd | sshd*) RUN_METHOD="cli" ;;
     php-fpm*) RUN_METHOD="web button" ;;
     *) RUN_METHOD="unknown" ;;
     esac

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -8,6 +8,8 @@ DEFAULT_CONFIG="/usr/local/emhttp/plugins/ca.mover.tuning/default.cfg"
 CRON="/boot/config/plugins/ca.mover.tuning/mover.cron"
 UNRAID_CRON="/boot/config/plugins/dynamix/mover.cron*"
 OVERRIDE_CFGFOLDER="/boot/config/plugins/ca.mover.tuning/shareOverrideConfig"
+PIDFILE="/var/run/mover.pid"
+SOFTSTOPFILE="/var/run/moversoft.stop"
 
 # Get parent Logs Folder from config, if blank set to default /tmp
 LOGFOLDER=$(grep "loggingFolder=" "$CONFIG" | cut -d '"' -f 2)
@@ -174,6 +176,31 @@ fi
         echo
     done
 } >$DEBUGROOT/PLUGIN/pools.txt 2>&1
+
+# Who holds the mover now. A pid file left by the stock mover, or one whose pid is
+# dead, explains both "already running" and a run that overlapped the stock mover.
+mover_state() {
+    echo "### $PIDFILE"
+    if [ -f "$PIDFILE" ]; then
+        local pid
+        pid=$(tr -cd '0-9' <"$PIDFILE")
+        if [ -n "$pid" ] && [ -r "/proc/$pid/cmdline" ]; then
+            printf 'pid=%s etime=%s cmdline=' "$pid" "$(ps -o etime= -p "$pid" | tr -d ' ')"
+            tr '\0' ' ' <"/proc/$pid/cmdline"
+            echo
+        else
+            echo "pid=${pid:-?} not running (stale pid file)"
+        fi
+    else
+        echo "absent"
+    fi
+    [ -e "$SOFTSTOPFILE" ] && echo "### $SOFTSTOPFILE present"
+    echo "### mover processes"
+    pgrep -af 'age_mover|share_mover|sbin/mover|unraid/move' || echo "none"
+    echo "### emhttpd"
+    grep -E '^shareMover(Active|Schedule)=' /var/local/emhttp/var.ini
+}
+mover_state >$DEBUGROOT/PLUGIN/mover_state.txt 2>&1
 
 # include unraid version in package
 [ -f /etc/unraid-version ] && cp -f /etc/unraid-version $DEBUGROOT/unraid-version.txt 2>&1

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -188,6 +188,8 @@ mover_state() {
             printf 'pid=%s etime=%s cmdline=' "$pid" "$(ps -o etime= -p "$pid" | tr -d ' ')"
             tr '\0' ' ' <"/proc/$pid/cmdline"
             echo
+            # same test the mover itself uses to refuse a second run (age_mover, share_mover)
+            ps h "$pid" | grep -q mover || echo "pid=$pid is not a mover (reused pid, so the pid file is stale)"
         else
             echo "pid=${pid:-?} not running (stale pid file)"
         fi

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/mover.php
@@ -50,6 +50,8 @@ function runMover($cmd)
     logger("Detached from web request; mover output continues in syslog and the mover log");
     // stdout is discarded rather than piped to logger: on this path age_mover's
     // mvlogger already writes each message to syslog, so piping would double it.
+    // The run outlives the request and reparents to PID 1, so name the launcher.
+    putenv("MOVER_RUN_METHOD=web button");
     exec($cmd . " >/dev/null 2>&1 &");
 
     // Wait for the run to claim the pid file so the page's status poll does


### PR DESCRIPTION
Two gaps found while reading a "moves nothing" report from a 7.3.1 box on 2026.08.29.

**Debug package: mover state.** The syslog in that zip showed the stock mover start at 18:47:32 with no "finished" line, and a plugin run two minutes later that found no live pid. Nothing in the package separates a stale pid file from an overlapping run. `debug_mover` now writes `PLUGIN/mover_state.txt`: the pid file (pid, elapsed time and command line, or "stale"), the soft-stop file, matching mover processes, and emhttpd's `shareMoverActive` / `shareMoverSchedule`. It passes through the same anonymizer as the rest of the plugin half.

**`Run by: unknown` on every web run since 2026.08.21.** The web path detaches the run, so it reparents to PID 1 and the ancestor walk never sees php-fpm. `mover.php` now names the launcher through `MOVER_RUN_METHOD` on that path and `age_mover` honours it before walking the tree; cron and CLI keep the walk. An ssh session (`sshd`) now counts as `cli` instead of `unknown`. `IS_CRON`, and with it the echo-only logging for cron runs, is unchanged.

Tested on 7.3.1, bash 5.3:

| case | before | after |
|---|---|---|
| detached launch with the variable, `sh -c` + `ionice` + `nice`, ppid 1 | unknown | web button |
| detached launch without the variable | unknown | unknown |
| ssh session | unknown | cli |
| `MOVER_RUN_METHOD=cron` | – | cron, `IS_CRON=1` |
| snapshot with no pid file / stale pid / live pid | – | `absent` / `not running (stale pid file)` / pid, etime, cmdline |
| snapshot process match on `/usr/local/sbin/mover` | – | listed |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer reporting of the mover’s current state, including active processes, stop markers, scheduling status, and process details.
  - Web-triggered mover runs now identify their launch method for improved visibility in related scripts and diagnostics.
  - Mover execution-source detection now recognizes configured launch methods and identifies sessions launched through supported terminal access methods.
  - Improved stale process tracking by distinguishing active mover processes from reused or outdated process identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->