### PR TITLE
Create a GitHub release after the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,9 +75,21 @@ jobs:
         path: release_info.json
 
     - name: Commit updated files
+      id: commit
       if: ${{ inputs.publish }}
       uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
       with:
         repository: ca.mover.tuning
         commit_message: "Auto-build: ${{ steps.validate.outputs.package }}"
         file_pattern: README.md archive/ plugins/ source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/default.cfg
+
+    - name: Create GitHub release
+      if: ${{ steps.commit.outputs.changes_detected == 'true' }}
+      uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
+      with:
+        tag_name: ${{ steps.validate.outputs.version }}
+        name: Mover Tuning ${{ steps.validate.outputs.version }}
+        target_commitish: ${{ steps.commit.outputs.commit_hash }}
+        body_path: ca.mover.tuning/.updates.txt
+        files: ca.mover.tuning/archive/${{ steps.validate.outputs.package }}
+        fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   PLUGIN_NAME: ca.mover.tuning
 
@@ -54,6 +58,17 @@ jobs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
         echo "package=$package" >> "$GITHUB_OUTPUT"
 
+    - name: Check the version is not already released
+      if: ${{ inputs.publish }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ steps.validate.outputs.version }}
+      run: |
+        if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" >/dev/null 2>&1; then
+          echo "Version $VERSION is already released. Re-run with a suffix (a, or .1) to build again today." >&2
+          exit 1
+        fi
+
     - name: Write release info
       env:
         VERSION: ${{ steps.validate.outputs.version }}
@@ -84,7 +99,7 @@ jobs:
         file_pattern: README.md archive/ plugins/ source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/default.cfg
 
     - name: Create GitHub release
-      if: ${{ steps.commit.outputs.changes_detected == 'true' }}
+      if: ${{ steps.commit.outputs.changes_detected == 'true' && github.ref == 'refs/heads/master' }}
       uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
       with:
         tag_name: ${{ steps.validate.outputs.version }}


### PR DESCRIPTION
This adds one step to `build.yml`. It runs after "Commit updated files".

When you run the build with **publish** on, it now also:

- creates the tag (for example `2026.09.06`) on the auto-build commit
- creates a GitHub release with that tag
- uploads the txz package to the release
- uses `.updates.txt` as the release notes

Why one file, and not a separate `release.yml`:

- A tag pushed by a workflow does not start other workflows. This is a GitHub rule for `GITHUB_TOKEN`. So a separate file with `on: push: tags` would only work when you push a tag by hand.
- The build already knows the version, the package name and the new commit. So it is simple to make the release in the same run.

Notes:

- Run **publish** on `master` for a real release.
- Do not run **publish** two times for the same version. A tag cannot be moved. For a second build on the same day, use a suffix.
- The Discord message for a new release still comes from the build run. There is no second message.

Tested on my fork: https://github.com/chodeus/ca.mover.tuning/actions/runs/34000600503. It created the tag and the release on the auto-build commit and uploaded the txz. The md5 of the uploaded file matched the plg. I deleted the test release after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Prevented concurrent workflow runs for the same branch or reference from canceling one another.
  - Added validation to prevent publishing a release when the version tag already exists.
  - Restricted automatic GitHub release creation to the master branch.
  - Automatic releases continue to use the validated build version and include the built package archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->