### PR TITLE
Hide file names in share-relative paths in the debug package

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -41,13 +41,15 @@ function mangle_leaf(s,   i) {
     return mangle(s)
 }
 
-function mangle_path(p,   parts, n, i, out) {
+function mangle_path(p,   parts, n, i, out, abs, keep) {
+    # the i<=3 prefix is "", "mnt", "<pool>" - it only holds for an absolute path.
+    # Mover_action rows are share-relative, so there it would keep three real names.
+    abs = (substr(p, 1, 1) == "/")
     n = split(p, parts, "/")
     out = ""
     for (i = 1; i <= n; i++) {
-        if (i <= 3 || parts[i] in pool || parts[i] in share)
-            out = out (i > 1 ? "/" : "") parts[i]
-        else out = out "/" mangle_leaf(parts[i])
+        keep = ((abs && i <= 3) || parts[i] in pool || parts[i] in share)
+        out = out (i > 1 ? "/" : "") (keep ? parts[i] : mangle_leaf(parts[i]))
     }
     return out
 }

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -42,13 +42,15 @@ function mangle_leaf(s,   i) {
 }
 
 function mangle_path(p,   parts, n, i, out, abs, keep) {
-    # the i<=3 prefix is "", "mnt", "<pool>" - it only holds for an absolute path.
-    # Mover_action rows are share-relative, so there it would keep three real names.
+    # Absolute paths are /mnt/<pool>/<share>/..., so the readable prefix is parts 1-4.
+    # Mover_action rows are share-relative, so there the share is part 1 and nothing else
+    # is structural - a deeper folder named after a share is somebody's data, not a share.
     abs = (substr(p, 1, 1) == "/")
     n = split(p, parts, "/")
     out = ""
     for (i = 1; i <= n; i++) {
-        keep = ((abs && i <= 3) || parts[i] in pool || parts[i] in share)
+        if (abs) keep = (i <= 3 || (i == 4 && parts[i] in share))
+        else keep = (i == 1 && (parts[i] in share || parts[i] in pool))
         out = out (i > 1 ? "/" : "") (keep ? parts[i] : mangle_leaf(parts[i]))
     }
     return out


### PR DESCRIPTION
The debug package hides file names, but not in `Mover_action_*.list`.

Paths in that list are share-relative (`share/folder/file.mkv`). The anonymiser keeps the first three
parts of a path, because for an absolute path those are `""`, `mnt` and the pool name. On a relative
path the same rule keeps three real names instead, so a file within three levels of the share root
keeps its own name. The same file is hidden correctly in `Filtered_files_*.list`, which stores
absolute paths.

On my server 640 file rows went through that path.

The fix is one condition: only keep the first three parts when the path starts with `/`. Pool and
share names are still kept, because they are matched by name.

Before and after, same awk, same input:

| path in the list | before | after |
|---|---|---|
| `/mnt/cache/myshare/f.bin` | `/mnt/cache/myshare/-.bin` | `/mnt/cache/myshare/-.bin` |
| `myshare/f.bin` | `myshare/f.bin` | `myshare/-.bin` |
| `data/secret.txt` | `data/secret.txt` | `data/------.txt` |
| `data/media/movies/The Title (2020)/The.Title.2020.mkv` | `data/media/movies/----------------/--------------.mkv` | `data/-----/------/----------------/--------------.mkv` |
| `appdata` (a share name) | `appdata` | `appdata` |

Tested on Unraid 7.3.2: a debug package built with this change has 0 of 640 file rows with a real
name after the share name, and absolute paths are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path handling in mover tuning output.
  - Absolute paths now preserve their expected leading components and recognized share names.
  - Share-relative paths now preserve only recognized pool or share names in the correct position while masking other components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->