### PR TITLE
Say what a freeing threshold above the moving threshold actually does

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -2332,7 +2332,7 @@ processTheMoves() {
 # lower moving threshold while the old freeing value is still selected.
 warn_freeing_above_moving() {
     if [ "$FREEINGPCTLIMIT" -gt "$MOVINGPCTTHRESHOLD" ]; then
-        mvlogger "Warning: Freeing threshold ($FREEINGPCTLIMIT%) is above the moving threshold ($MOVINGPCTTHRESHOLD%), so no file can be moved. The settings page will show the freeing threshold as $MOVINGPCTTHRESHOLD% until it is saved again."
+        mvlogger "Warning: Freeing threshold ($FREEINGPCTLIMIT%) is above the moving threshold ($MOVINGPCTTHRESHOLD%). The mover starts at $MOVINGPCTTHRESHOLD% and stops at $FREEINGPCTLIMIT%, so nothing is moved while the pool sits between them. The settings page will show the freeing threshold as $MOVINGPCTTHRESHOLD% until it is saved again."
     fi
 }
 


### PR DESCRIPTION
The warning added in #169 says more than it should.

Current text, when the freeing threshold is above the moving threshold:

> Freeing threshold (25%) is above the moving threshold (10%), **so no file can be moved.**

That last part is only true some of the time. The mover starts when the pool is above the moving
threshold and stops when it reaches the freeing threshold, so:

- pool below the moving threshold — the run does not start (nothing to do with this setting)
- pool between the two — nothing is moved, and the warning is right
- pool above the freeing threshold — files **are** moved, down to the freeing threshold

I hit the third case while testing on Unraid 7.3.2: freeing 25 %, moving 10 %, pool at 29 %, and the
run planned 3 files and 98 GiB. The warning said no file could be moved.

New text:

> Freeing threshold (25%) is above the moving threshold (10%). The mover starts at 10% and stops at
> 25%, so nothing is moved while the pool sits between them. The settings page will show the freeing
> threshold as 10% until it is saved again.

The condition is unchanged, so the warning still appears in exactly the same cases. The second
sentence is unchanged and still correct: the freeing list on the settings page only offers values up
to the moving threshold, so a saved 25 % matches no option and the page shows 10 %.

Checked with the real function: warns at freeing 25 / moving 10, silent at 25 / 55 and at 40 / 40.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the mover warning message to clarify that files are not moved when pool usage is between the moving and freeing thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->