### PR TITLE
Stop the debug package leaking file names and eating log text

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -314,6 +314,10 @@ escape_find_path() {
 #   1 → echo + log file
 #   2 → log file only
 #
+# Wraps a path for a log message: the debug package ends a path at the quote, so an
+# embedded quote - an edge case, but the last redaction hole - would expose the rest.
+qp() { local p=${1//\\/\\\\}; printf '"%s"' "${p//\"/\\\"}"; }
+
 mvlogger() {
     local msg="$1"
     local notify="$2"
@@ -1004,7 +1008,7 @@ createFilteredFilelist() {
         # Check if the storage exists
         if [ ! -d "/mnt/$PRIMARYSTORAGENAME" ]; then
             # Do not process this pool if path does not exist
-            mvlogger "\"/mnt/$PRIMARYSTORAGENAME\" does not exist. Is the pool still used? Consider removing $SHARECFG if not."
+            mvlogger "$(qp "/mnt/$PRIMARYSTORAGENAME") does not exist. Is the pool still used? Consider removing $SHARECFG if not."
             mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
             mvlogger "=> Skipping"
             continue # Move to the next iteration of the loop
@@ -1076,12 +1080,12 @@ createFilteredFilelist() {
             # Check if share mount point is ZFS
             if is_zfs_pool "$PRIMARYSTORAGENAME"; then
                 # Do not process this pool if path does not exist
-                mvlogger "\"$SHAREPATH\" does not exist. Is the ZFS dataset not created yet? Copy files to \"/mnt/user/$SHARENAME\" first."
+                mvlogger "$(qp "$SHAREPATH") does not exist. Is the ZFS dataset not created yet? Copy files to $(qp "/mnt/user/$SHARENAME") first."
                 mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
                 mvlogger "=> Skipping"
             else
                 # Do not process this pool if path does not exist
-                mvlogger "\"$SHAREPATH\" does not exist. Is the share still used? Consider removing $SHARECFG if not."
+                mvlogger "$(qp "$SHAREPATH") does not exist. Is the share still used? Consider removing $SHARECFG if not."
                 mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
                 mvlogger "=> Skipping"
             fi
@@ -1120,7 +1124,7 @@ createFilteredFilelist() {
                         COUNT_SECONDARY_FILES=$((COUNT_SECONDARY_FILES + tmp))
                     else
                         # Do not process this pool if path does not exist
-                        mvlogger "Nothing to bring back: this cache:prefer share has no files on secondary storage (\"$SECONDARY_SHAREPATH\" does not exist)."
+                        mvlogger "Nothing to bring back: this cache:prefer share has no files on secondary storage ($(qp "$SECONDARY_SHAREPATH") does not exist)."
                         mvlogger "=> Skipping"
                         continue # Move to the next iteration of the loop
                     fi
@@ -1938,7 +1942,7 @@ processTheMoves() {
             if [[ "$FILETYPE" == "d" && "$ACTION" =~ "move" ]]; then
                 # If the directory is listed in the skiplist, skip it
                 if [[ -n "$SKIPFILESLIST" && -f "$SKIPFILESLIST" ]] && grep -q "${SOURCE}/${FILEPATH}" "$SKIPFILESLIST"; then
-                    mvlogger "Skipping empty folder \"${SOURCE}/${FILEPATH}\" as it is listed in the skip list."
+                    mvlogger "Skipping empty folder $(qp "${SOURCE}/${FILEPATH}") as it is listed in the skip list."
                     continue # do not move this folder
                 fi
             fi
@@ -1957,7 +1961,7 @@ processTheMoves() {
             # Check File by validate function and skip if error
             if [ "$VALIDATE_FILENAMES" = "yes" ]; then
                 if ! validate_filename "$(basename "$FILEPATH")"; then
-                    mvlogger "Error: Invalid filename path: \"$SOURCE/$FILEPATH\". Please either change the filename to valid or disable the 'Validate input filenames' option." "failure"
+                    mvlogger "Error: Invalid filename path: $(qp "$SOURCE/$FILEPATH"). Please either change the filename to valid or disable the 'Validate input filenames' option." "failure"
                     continue
                 #else
                 #    mvlogger "Valid filename"
@@ -1972,7 +1976,8 @@ processTheMoves() {
             # SYNCED_FILES is a display/count string only, derived from the array so
             # the extraction pipeline above runs only once per file.
             SYNCED_FILES=""
-            [[ ${#SYNCED_FILES_ARR[@]} -gt 0 ]] && printf -v SYNCED_FILES '"%s" ' "${SYNCED_FILES_ARR[@]}"
+            SYNCED_FILES=""
+            for f in "${SYNCED_FILES_ARR[@]}"; do SYNCED_FILES+="$(qp "$f") "; done
             GUI_CURRENT_FILE=$SYNCED_FILES
 
             # Check if list is complete (array length is exact, unlike parsing the string)
@@ -1986,14 +1991,14 @@ processTheMoves() {
             if [[ "$ACTION" =~ "move" ]]; then
                 # Some verbosity
                 GUI_ACTION="Moving to $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
-                mvlogger "Moving $SYNCED_FILES to  \"$DESTINATION/\" $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
+                mvlogger "Moving $SYNCED_FILES to  $(qp "$DESTINATION/") $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
                 rsync_action="Move"
                 # Finalize RSYNC_CMD
                 RSYNC_CMD+=(--remove-source-files)
             elif [[ "$ACTION" =~ "sync" ]]; then
                 # Some verbosity
                 GUI_ACTION="Synchronizing to $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
-                mvlogger "Synchronizing  $SYNCED_FILES to  \"$DESTINATION/\" $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
+                mvlogger "Synchronizing  $SYNCED_FILES to  $(qp "$DESTINATION/") $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
                 rsync_action="Sync"
             fi
 
@@ -2010,7 +2015,7 @@ processTheMoves() {
                 if [ "$TESTMODE" = "yes" ]; then
                     mvlogger "TEST MODE: Would move using Unraid move utility"
                 else
-                    mvDebuglogger "Move cmd: move, Move $filetype: \"$SOURCE/$FILEPATH\", Dest: \"$DESTINATION/\"" "Move Action"
+                    mvDebuglogger "Move cmd: move, Move $filetype: $(qp "$SOURCE/$FILEPATH"), Dest: $(qp "$DESTINATION/")" "Move Action"
                     # Perform unraid binary move.
                     find "$SOURCE/$FILEPATH" | /usr/libexec/unraid/move "$DEBUGGING" >>"$MOVER_DEBUG_LOG" 2>&1
                 fi
@@ -2021,13 +2026,14 @@ processTheMoves() {
                 else
                     # one quoted token per argv element, like SYNCED_FILES above: [*] joins the
                     # paths with spaces, and the anonymiser cannot tell where one ends
-                    printf -v RSYNC_CMD_LOG '"%s" ' "${RSYNC_CMD[@]}"
-                    mvDebuglogger "Rsync cmd: $RSYNC_CMD_LOG, $rsync_action $filetype: $SYNCED_FILES, Dest: \"$DESTINATION/\"" "$rsync_action Action"
+                    RSYNC_CMD_LOG=""
+                    for a in "${RSYNC_CMD[@]}"; do RSYNC_CMD_LOG+="$(qp "$a") "; done
+                    mvDebuglogger "Rsync cmd: $RSYNC_CMD_LOG, $rsync_action $filetype: $SYNCED_FILES, Dest: $(qp "$DESTINATION/")" "$rsync_action Action"
                     # Perform rsync. relative paths and hardlinks
                     if [ ${#SYNCED_FILES_ARR[@]} -gt 0 ]; then
                         "${RSYNC_CMD[@]}" "${SYNCED_FILES_ARR[@]}" "$DESTINATION/"
                     else
-                        mvlogger "Error: No files found to move for \"$SOURCE/$FILEPATH\"" "failure"
+                        mvlogger "Error: No files found to move for $(qp "$SOURCE/$FILEPATH")" "failure"
                     fi
                 fi
             fi

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1004,7 +1004,7 @@ createFilteredFilelist() {
         # Check if the storage exists
         if [ ! -d "/mnt/$PRIMARYSTORAGENAME" ]; then
             # Do not process this pool if path does not exist
-            mvlogger "/mnt/$PRIMARYSTORAGENAME does not exist. Is the pool still used? Consider removing $SHARECFG if not."
+            mvlogger "\"/mnt/$PRIMARYSTORAGENAME\" does not exist. Is the pool still used? Consider removing $SHARECFG if not."
             mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
             mvlogger "=> Skipping"
             continue # Move to the next iteration of the loop
@@ -1076,12 +1076,12 @@ createFilteredFilelist() {
             # Check if share mount point is ZFS
             if is_zfs_pool "$PRIMARYSTORAGENAME"; then
                 # Do not process this pool if path does not exist
-                mvlogger "$SHAREPATH does not exist. Is the ZFS dataset not created yet? Copy files to '/mnt/user/$SHARENAME' first."
+                mvlogger "\"$SHAREPATH\" does not exist. Is the ZFS dataset not created yet? Copy files to '/mnt/user/$SHARENAME' first."
                 mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
                 mvlogger "=> Skipping"
             else
                 # Do not process this pool if path does not exist
-                mvlogger "$SHAREPATH does not exist. Is the share still used? Consider removing $SHARECFG if not."
+                mvlogger "\"$SHAREPATH\" does not exist. Is the share still used? Consider removing $SHARECFG if not."
                 mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
                 mvlogger "=> Skipping"
             fi
@@ -1120,7 +1120,7 @@ createFilteredFilelist() {
                         COUNT_SECONDARY_FILES=$((COUNT_SECONDARY_FILES + tmp))
                     else
                         # Do not process this pool if path does not exist
-                        mvlogger "$PRIMARY_SHAREPATH exist but $SECONDARY_SHAREPATH does not exist. Is the share on secondary storage not created yet?"
+                        mvlogger "Nothing to bring back: this cache:prefer share has no files on secondary storage (\"$SECONDARY_SHAREPATH\" does not exist)."
                         mvlogger "=> Skipping"
                         continue # Move to the next iteration of the loop
                     fi
@@ -1139,7 +1139,7 @@ createFilteredFilelist() {
                     # Check if no paths were found
                     if [[ -z "$PREFER_SHAREPATH" ]]; then
                         # Do not process this pool if path does not exist
-                        mvlogger "$PRIMARY_SHAREPATH exist but no disk paths found for $SHARENAME in $SECONDARYSTORAGENAME. Is the share on secondary storage not created yet?"
+                        mvlogger "Nothing to bring back: this cache:prefer share has no files on the array (no \"$SHARENAME\" folder on any array disk)."
                         mvlogger "=> Skipping"
                         continue # Move to the next iteration of the loop
                     fi
@@ -1986,14 +1986,14 @@ processTheMoves() {
             if [[ "$ACTION" =~ "move" ]]; then
                 # Some verbosity
                 GUI_ACTION="Moving to $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
-                mvlogger "Moving $SYNCED_FILES to  $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
+                mvlogger "Moving $SYNCED_FILES to  \"$DESTINATION/\" $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
                 rsync_action="Move"
                 # Finalize RSYNC_CMD
                 RSYNC_CMD+=(--remove-source-files)
             elif [[ "$ACTION" =~ "sync" ]]; then
                 # Some verbosity
                 GUI_ACTION="Synchronizing to $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
-                mvlogger "Synchronizing  $SYNCED_FILES to  $DESTINATION/ $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
+                mvlogger "Synchronizing  $SYNCED_FILES to  \"$DESTINATION/\" $([ "$NBLINKS" -gt 1 ] && [ -f "$FILEPATH" ] && echo '(preserving hardlinks)')"
                 rsync_action="Sync"
             fi
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -1076,7 +1076,7 @@ createFilteredFilelist() {
             # Check if share mount point is ZFS
             if is_zfs_pool "$PRIMARYSTORAGENAME"; then
                 # Do not process this pool if path does not exist
-                mvlogger "\"$SHAREPATH\" does not exist. Is the ZFS dataset not created yet? Copy files to '/mnt/user/$SHARENAME' first."
+                mvlogger "\"$SHAREPATH\" does not exist. Is the ZFS dataset not created yet? Copy files to \"/mnt/user/$SHARENAME\" first."
                 mvlogger "Tip: Safely remove unused shares via the Unraid Shares -> Clean Up button."
                 mvlogger "=> Skipping"
             else
@@ -1957,7 +1957,7 @@ processTheMoves() {
             # Check File by validate function and skip if error
             if [ "$VALIDATE_FILENAMES" = "yes" ]; then
                 if ! validate_filename "$(basename "$FILEPATH")"; then
-                    mvlogger "Error: Invalid filename path: '$FILEPATH'. Please either change the filename to valid or disable the 'Validate input filenames' option." "failure"
+                    mvlogger "Error: Invalid filename path: \"$SOURCE/$FILEPATH\". Please either change the filename to valid or disable the 'Validate input filenames' option." "failure"
                     continue
                 #else
                 #    mvlogger "Valid filename"
@@ -2010,7 +2010,7 @@ processTheMoves() {
                 if [ "$TESTMODE" = "yes" ]; then
                     mvlogger "TEST MODE: Would move using Unraid move utility"
                 else
-                    mvDebuglogger "Move cmd: move, Move $filetype: $SOURCE/$FILEPATH, Dest: $DESTINATION/" "Move Action"
+                    mvDebuglogger "Move cmd: move, Move $filetype: \"$SOURCE/$FILEPATH\", Dest: \"$DESTINATION/\"" "Move Action"
                     # Perform unraid binary move.
                     find "$SOURCE/$FILEPATH" | /usr/libexec/unraid/move "$DEBUGGING" >>"$MOVER_DEBUG_LOG" 2>&1
                 fi
@@ -2019,12 +2019,15 @@ processTheMoves() {
                 if [ "$TESTMODE" = "yes" ]; then
                     mvlogger "TEST MODE: Would $rsync_action using rsync utility"
                 else
-                    mvDebuglogger "Rsync cmd: ${RSYNC_CMD[*]}, $rsync_action $filetype: $SYNCED_FILES, Dest: $DESTINATION/" "$rsync_action Action"
+                    # one quoted token per argv element, like SYNCED_FILES above: [*] joins the
+                    # paths with spaces, and the anonymiser cannot tell where one ends
+                    printf -v RSYNC_CMD_LOG '"%s" ' "${RSYNC_CMD[@]}"
+                    mvDebuglogger "Rsync cmd: $RSYNC_CMD_LOG, $rsync_action $filetype: $SYNCED_FILES, Dest: \"$DESTINATION/\"" "$rsync_action Action"
                     # Perform rsync. relative paths and hardlinks
                     if [ ${#SYNCED_FILES_ARR[@]} -gt 0 ]; then
                         "${RSYNC_CMD[@]}" "${SYNCED_FILES_ARR[@]}" "$DESTINATION/"
                     else
-                        mvlogger "Error: No files found to move for $FILEPATH" "failure"
+                        mvlogger "Error: No files found to move for \"$SOURCE/$FILEPATH\"" "failure"
                     fi
                 fi
             fi

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/age_mover
@@ -2047,7 +2047,7 @@ processTheMoves() {
                     # Collapse the rsync --relative marker ("/./" -> "/")
                     FILE="${FILE//\/.\//\/}"
                     DIR=$(dirname "$FILE")
-                    mvDebuglogger "Current file: $FILE, Current folder: $DIR, Previous folder: $LAST_DIR, Previous count: $LAST_COUNT" "Clean Folder - Start Loop"
+                    mvDebuglogger "Current file: $(qp "$FILE"), Current folder: $(qp "$DIR"), Previous folder: $(qp "$LAST_DIR"), Previous count: $LAST_COUNT" "Clean Folder - Start Loop"
 
                     if [ -e "${DIR}/.placeholder" ]; then
                         count=".placeholder"
@@ -2149,9 +2149,9 @@ processTheMoves() {
                 if [ ! -d "$START_DIR" ]; then
                     START_DIR="$(dirname "${START_DIR}")"
                     if [ -d "$START_DIR" ]; then
-                        mvDebuglogger "Skipping cleanup: $START_DIR no longer exists, using upper folder: $(dirname "${START_DIR}")" "Clean Empty Moved Folder"
+                        mvDebuglogger "Skipping cleanup: $(qp "$START_DIR") no longer exists, using upper folder: $(qp "$(dirname "${START_DIR}")")" "Clean Empty Moved Folder"
                     else
-                        mvDebuglogger "Skipping cleanup: $START_DIR no longer exists" "Clean Empty Moved Folder"
+                        mvDebuglogger "Skipping cleanup: $(qp "$START_DIR") no longer exists" "Clean Empty Moved Folder"
                         continue
                     fi
                 fi
@@ -2231,7 +2231,7 @@ processTheMoves() {
                             file_count=$(find "$top_folder" -type f | wc -l)
                             dir_count=$(find "$top_folder" -mindepth 1 -type d | wc -l)
 
-                            mvDebuglogger "Top folder: $top_folder, share file(s): $file_count, share folder(s): $dir_count" "Clean Top Folder"
+                            mvDebuglogger "Top folder: $(qp "$top_folder"), share file(s): $file_count, share folder(s): $dir_count" "Clean Top Folder"
 
                             # Delete only if truly empty
                             if [ "$file_count" -eq 0 ] && [ "$dir_count" -eq 0 ]; then

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -73,7 +73,9 @@ LIST && NF > 1 { $NF = mangle_path($NF); print; next }
     # mangle_leaf runs its own match() and would clobber RSTART/RLENGTH.
     # So a log message must quote a path it puts mid-sentence - only the caller knows
     # where the path ends, and unquoted the prose after it is mangled away too.
-    while (match(line, /\/mnt\/[^"',;|]*/)) {
+    # Only the quote terminates: , ; | and ' are all legal in a file name, and any of
+    # them in the terminator set leaks the rest of the name ("Ocean's Eleven").
+    while (match(line, /\/mnt\/[^"]*/)) {
         st = RSTART; len = RLENGTH
         tok = substr(line, st, len); tail = ""
         # trailing blanks belong to the line, not the path

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -41,6 +41,18 @@ function mangle_leaf(s,   i) {
     return mangle(s)
 }
 
+# the producer escapes \ and " inside a path (qp in age_mover/share_mover); undo that
+# before measuring, so a name is dashed to its real length
+function unescape(s,   out, i, c) {
+    out = ""
+    for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (c == "\\" && i < length(s)) { i++; c = substr(s, i, 1) }
+        out = out c
+    }
+    return out
+}
+
 function mangle_path(p,   parts, n, i, out, abs, keep) {
     # Absolute paths are /mnt/<pool>/<share>/..., so the readable prefix is parts 1-4.
     # Mover_action rows are share-relative, so there the share is part 1 and nothing else
@@ -73,14 +85,14 @@ LIST && NF > 1 { $NF = mangle_path($NF); print; next }
     # mangle_leaf runs its own match() and would clobber RSTART/RLENGTH.
     # So a log message must quote a path it puts mid-sentence - only the caller knows
     # where the path ends, and unquoted the prose after it is mangled away too.
-    # Only the quote terminates: , ; | and ' are all legal in a file name, and any of
-    # them in the terminator set leaks the rest of the name ("Ocean's Eleven").
-    while (match(line, /\/mnt\/[^"]*/)) {
+    # Only an UNESCAPED quote terminates: , ; | ' and " are all legal in a file name and
+    # any of them ending the match leaks the rest of it. ' and , are common, " is an edge case.
+    while (match(line, /\/mnt\/(\\.|[^"\\])*/)) {
         st = RSTART; len = RLENGTH
         tok = substr(line, st, len); tail = ""
         # trailing blanks belong to the line, not the path
         if (match(tok, /[ \t]+$/)) { tail = substr(tok, RSTART); tok = substr(tok, 1, RSTART - 1) }
-        out = out substr(line, 1, st - 1) mangle_path(tok) tail
+        out = out substr(line, 1, st - 1) mangle_path(unescape(tok)) tail
         line = substr(line, st + len)
     }
     print out line

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/debug_mover
@@ -71,6 +71,8 @@ LIST && NF > 1 { $NF = mangle_path($NF); print; next }
     out = ""
     # spaces are not a terminator: file names contain them. copy st/len first,
     # mangle_leaf runs its own match() and would clobber RSTART/RLENGTH.
+    # So a log message must quote a path it puts mid-sentence - only the caller knows
+    # where the path ends, and unquoted the prose after it is mangled away too.
     while (match(line, /\/mnt\/[^"',;|]*/)) {
         st = RSTART; len = RLENGTH
         tok = substr(line, st, len); tail = ""

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
@@ -5,6 +5,10 @@ UNRAIDCFGFILE="/boot/config/share.cfg"
 MOVERTUNINGCFGFILE="/boot/config/plugins/ca.mover.tuning/ca.mover.tuning.cfg"
 LOGLEVEL=0
 
+# Wraps a path for a log message: the debug package ends a path at the quote, so an
+# embedded quote - an edge case, but the last redaction hole - would expose the rest.
+qp() { local p=${1//\\/\\\\}; printf '"%s"' "${p//\"/\\\"}"; }
+
 # Function for verbose output and logging
 mvlogger() {
     if [ $LOGLEVEL = 1 ]; then
@@ -157,7 +161,7 @@ if grep -qs 'shareUseCache="yes\|shareUseCache="prefer"' "$SHARECFG"; then
     # Check if the storage exists
     if [ ! -d "/mnt/$PRIMARYSTORAGENAME" ]; then
         # Do not process this pool if path does not exist
-        mvlogger "\"/mnt/$PRIMARYSTORAGENAME\" does not exist. Is the pool still used? Consider removing $SHARECFG if not."
+        mvlogger "$(qp "/mnt/$PRIMARYSTORAGENAME") does not exist. Is the pool still used? Consider removing $SHARECFG if not."
         mvlogger "=> Skipping"
         exit
     fi
@@ -186,7 +190,7 @@ if grep -qs 'shareUseCache="yes\|shareUseCache="prefer"' "$SHARECFG"; then
     mvlogger "Share Information: Name: $SHARENAME - Path: $SHAREPATH"
     if [ ! -d "$SHAREPATH" ]; then # && [ $SHAREUSECACHE != "no" ]
         # Do not process this pool if path does not exist
-        mvlogger "\"$SHAREPATH\" does not exist or is empty."
+        mvlogger "$(qp "$SHAREPATH") does not exist or is empty."
         mvlogger "=> Skipping"
     else
         mvlogger "$(titleLine 'LET THE MOVING SHOW BEGIN !' '*')"

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/share_mover
@@ -157,7 +157,7 @@ if grep -qs 'shareUseCache="yes\|shareUseCache="prefer"' "$SHARECFG"; then
     # Check if the storage exists
     if [ ! -d "/mnt/$PRIMARYSTORAGENAME" ]; then
         # Do not process this pool if path does not exist
-        mvlogger "/mnt/$PRIMARYSTORAGENAME does not exist. Is the pool still used? Consider removing $SHARECFG if not."
+        mvlogger "\"/mnt/$PRIMARYSTORAGENAME\" does not exist. Is the pool still used? Consider removing $SHARECFG if not."
         mvlogger "=> Skipping"
         exit
     fi
@@ -186,7 +186,7 @@ if grep -qs 'shareUseCache="yes\|shareUseCache="prefer"' "$SHARECFG"; then
     mvlogger "Share Information: Name: $SHARENAME - Path: $SHAREPATH"
     if [ ! -d "$SHAREPATH" ]; then # && [ $SHAREUSECACHE != "no" ]
         # Do not process this pool if path does not exist
-        mvlogger "$SHAREPATH does not exist or is empty."
+        mvlogger "\"$SHAREPATH\" does not exist or is empty."
         mvlogger "=> Skipping"
     else
         mvlogger "$(titleLine 'LET THE MOVING SHOW BEGIN !' '*')"


### PR DESCRIPTION
The debug package's anonymiser matches `/mnt/[^"',;|]*` and mangles every `/`-separated part of what it grabs. Spaces are deliberately not a terminator, because file names contain them — so a log message that puts a path mid-sentence loses the rest of the sentence with it.

Found in a real debug package from 7.3.2. Two lines came out as `/mnt/cache/` followed by 110 and 108 dashes. The originals were:

```
/mnt/cache/domains exist but no disk paths found for domains in user0. Is the share on secondary storage not created yet?
/mnt/cache/system exist but no disk paths found for system in user0. Is the share on secondary storage not created yet?
```

110 and 108 characters. The whole message was gone, share name included.

`system` and `domains` ship as `cache:prefer` on every Unraid install, so these are among the most frequently emitted messages in the plugin — destroyed in the one artifact users send here for triage.

## Fix

Only the caller knows where a path ends, so the paths that sit mid-sentence are now quoted, and the anonymiser stops on the closing quote. `age_mover:1941` and `:1960` already did this and were already unaffected — the fix converges on the file's existing convention.

Covered: pool missing, share missing, ZFS dataset missing, both `cache:prefer` messages, the `(preserving hardlinks)` note on move and sync, and the two `share_mover` equivalents. A comment on the anonymiser records why a caller must quote.

## Second change: the cache:prefer wording

For a `cache:prefer` share, nothing on secondary storage is the desired end state, not a fault — the files are all on the pool, which is what `prefer` asks for. The old text asked *"Is the share on secondary storage not created yet?"*, so every default install read a healthy `system` and `domains` as a problem twice per run.

```
- /mnt/cache/domains exist but no disk paths found for domains in user0. Is the share on secondary storage not created yet?
+ Nothing to bring back: this cache:prefer share has no files on the array (no "domains" folder on any array disk).
```

## Testing

Verified on 7.3.2 (bash 5.3), live run through the plugin's own `mover start`, then a real debug package generated with `debug_mover`.

Before the fix, in the packaged log:

```
04:58:11.604 /mnt/cache/--------------------------------------------------------------------------------------------------------------
```

After, in the packaged log:

```
04:58:11.604 Nothing to bring back: this cache:prefer share has no files on the array (no "domains" folder on any array disk).
04:58:11.734 Nothing to bring back: this cache:prefer share has no files on the array (no "system" folder on any array disk).
```

Anonymisation is unchanged — checked on the same package rather than assumed. The before/after script paths still come out as `/mnt/user/appdata/---------/------------------.sh`, and across 760 path fields in the action list the only surviving alphabetic tokens are share names (`data`, `appdata`) and file extensions (`flac`, `mkv`, `jpg`, `bin`, `json`, `txt`, `srt`). No file name survives.

A harness feeding the anonymiser (extracted from `debug_mover` itself, so it tests the shipped code) covers all six message shapes in both forms, plus three leak controls. Every shape fails in the old form and passes in the new one; the leak controls — a file name with spaces stays mangled, a folder below the share stays mangled, a share name stays readable — hold in both forms, so the change does not weaken anonymisation.

`bash -n` clean on all three files under bash 5.3.

---

## Follow-up commit: file names were leaking

Found while testing the above. Two separate leaks, both in code added by #167/#181.

**1. Four of the terminator characters are legal in file names.** The anonymiser stopped its `/mnt` match on `"`, `'`, `,`, `;` and `|`. Everything from the first one survived:

```
Ocean's Eleven.mkv   ->  -----'s Eleven.mkv
Movie, The (2020)    ->  -----, The (2020)
Artist; Live         ->  ------; Live
Rock|Paper           ->  ----|Paper
```

Apostrophes and commas are common in media names, which is most of this plugin's audience. Only the double quote is a delimiter the plugin controls, so the match now ends there and nowhere else. That is only safe because every message that puts a path mid-sentence now quotes it — the ZFS-dataset hint delimited its second path with single quotes and now uses double.

**2. Two messages logged a share-relative path.** `age_mover:1960` and `:2030` logged `$FILEPATH`, which is relative. The anonymiser only matches `/mnt`, so those names went into the package verbatim:

```
Error: Invalid filename path: 'data/Movies/Ocean's Eleven.mkv'. Please either change
```

`:1960` fires whenever *Validate Filenames* is on. Both log `$SOURCE/$FILEPATH` now, which the anonymiser matches and mangles.

Also logs the rsync argv one quoted token per element, matching how `SYNCED_FILES` is already built above it — `${RSYNC_CMD[*]}` joined the paths with spaces, so the anonymiser could not tell where one ended.

### Testing

The harness now runs 23 checks in three sections. Against upstream master the four leak controls fail; against this branch all 8 prose checks and all 8 leak controls pass, and the pre-fix wording still fails as the control.

Re-ran live on 7.3.2 and regenerated a real debug package. Across every packaged `.list.txt`, the only surviving words are share names (`data`, `appdata`), pool/structural names (`mnt`, `cache`) and file extensions (`flac`, `mkv`, `jpg`, `bin`, `json`, `txt`, `srt`). No file name survives.

---

## Third commit: escape quotes and backslashes

The double quote is itself legal in a file name, so ending the match on it left the same hole one character narrower — `"/mnt/user/Ocean"Secret.mkv"` anonymised only through `Ocean`, and `Secret.mkv` stayed in the package.

This one is an edge case and worth saying so: a quote in a file name is unlikely in practice, SMB/Windows refuses it and the *arr naming schemes strip it. Unlike `'` and `,`, which are everywhere in media names and were leaking constantly. Closed anyway, because it was the last hole left and a redactor that is sound except for one character is not sound.

`qp()` wraps a path for a log message and escapes `\` and `"` inside it; the 15 sites that logged a path call it instead of writing their own quotes. The anonymiser steps over an escaped character rather than ending on it, and unescapes before measuring so a name is still dashed to its real length. Backslash is escaped first — otherwise a name ending in one swallows the closing quote and the prose after it.

`.list.txt` rows are untouched: they carry the path as a whole field and never went through the quoting.

Four regression cases added. Final state, against the anonymiser extracted from the shipped `debug_mover`: **8 prose checks and 12 leak controls pass; upstream master fails 5 of the leak controls.** Re-ran live on 7.3.2 and regenerated the package — across every packaged list the only surviving words remain share names, pool names and file extensions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling in mover logs and diagnostics, including paths containing spaces, quotes, or backslashes.
  * Error and warning messages now show affected source and storage paths more clearly.
  * Improved anonymization of paths containing escaped characters while preserving accurate path lengths.
  * Updated path matching to correctly recognize valid special characters and quoted path boundaries.

* **Diagnostics**
  * Enhanced move and synchronization progress messages and debug command output for clearer, safer path representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->