### PR TITLE
Keep the freeing and Move All ranges in step with the moving threshold

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -23,8 +23,9 @@ $cronDisabled = ($cfg['force'] != "yes") ? "disabled" : "";
 $filelistfDisabled = ($cfg['filelistf'] != "yes") ? "disabled" : "";
 $filetypesfDisabled = ($cfg['filetypesf'] != "yes") ? "disabled" : "";
 $omoverthreshDisabled = ($cfg['omovercfg'] != "yes") ? "disabled" : "";
-$om = $cfg['movingThreshold']; $om = $om + 5;
-$f = $cfg['movingThreshold'];
+$movingSaved = (int)($cfg['movingThreshold'] ?? 0);
+$om = $movingSaved + 5;
+$f = $movingSaved;
 $sizefDisabled = ($cfg['sizef'] != "yes") ? "disabled" : "";
 $sizefSyncDisabled = ($cfg['sizefSync'] != "yes") ? "disabled" : "";
 $sparsnessfDisabled = ($cfg['sparsnessf'] != "yes") ? "disabled" : "";
@@ -235,6 +236,76 @@ function updateScreenMoverInvalidCharsToBlock(option,slow) {
   }
 }
 
+// What the config holds, before the selects below capped it to a range.
+var mtSaved = {
+  moving:   <?=(int)($cfg['movingThreshold'] ?? 0)?>,
+  freeing:  <?=(int)($cfg['freeingThreshold'] ?? 0)?>,
+  omover:   <?=strlen((string)($cfg['omoverthresh'] ?? '')) ? (int)$cfg['omoverthresh'] : 'null'?>,
+  omoverOn: <?=(($cfg['omovercfg'] ?? '') == 'yes') ? 'true' : 'false'?>
+};
+
+// Refills one select over [from..to]. Returns '' when the current value survived, else the
+// value it was clamped to.
+function mtFillRange(sel, from, to, step) {
+  var $sel = $(sel);
+  if (!$sel.length) return '';
+  if (step > 0 && from > to) from = to;
+  if (step < 0 && from < to) from = to;
+  var prev = $sel.val(), html = '', keep = false;
+  for (var v = from; step > 0 ? v <= to : v >= to; v += step) {
+    html += '<option value="' + v + '">' + v + ' %</option>';
+    if (String(v) === prev) keep = true;
+  }
+  $sel.html(html);
+  $sel.val(keep ? prev : $sel.find('option').first().val());
+  return keep ? '' : $sel.val();
+}
+
+function mtNotice(id, text) {
+  var $n = $(id);
+  if (!$n.length) return;
+  if (text) $n.html('<i class="fa fa-warning"></i> ' + text).show(); else $n.hide();
+}
+
+// Both ranges are derived from the moving threshold, so a range left over from an older
+// moving value would save a number nobody picked.
+function mtRebuildThresholds(moving) {
+  moving = parseInt(moving, 10) || 0;
+
+  var freeing = mtFillRange('select[name="freeingThreshold"]', moving, 0, -5);
+  mtNotice('#freeing_notice', freeing ? 'Freeing threshold lowered to ' + freeing +
+    '% to stay at or below the moving threshold.' : '');
+
+  var $om = $('select[name="omoverthresh"]');
+  var omover = mtFillRange($om, moving + 5, 100, 5);
+  mtNotice('#omoverthresh_notice', (omover && !$om.prop('disabled')) ?
+    'Move All threshold raised to ' + omover + '% to stay above the moving threshold.' : '');
+}
+
+// A config saved before the ranges tracked each other can hold a combination this page cannot
+// show, so it would display one value and store another until the next save.
+function mtWarnSavedThresholds() {
+  var msgs = [];
+  if (mtSaved.freeing > mtSaved.moving) {
+    msgs.push('The saved freeing threshold is ' + mtSaved.freeing + '%, above the moving threshold of ' +
+      mtSaved.moving + '%. The mover starts at ' + mtSaved.moving + '% and stops at ' + mtSaved.freeing +
+      '%, so nothing is moved while the pool sits between them. This page now shows ' +
+      $('select[name="freeingThreshold"]').val() + '%, and saving will store that.');
+  }
+  if (mtSaved.omoverOn && mtSaved.omover !== null && mtSaved.omover <= mtSaved.moving) {
+    msgs.push('The saved Move All threshold is ' + mtSaved.omover + '%, at or below the moving threshold ' +
+      'of ' + mtSaved.moving + '%. Everything on cache:yes shares moves, skip list and filters ignored, ' +
+      'before the moving threshold is reached. This page now shows ' +
+      $('select[name="omoverthresh"]').val() + '%, and saving will store that.');
+  }
+  if (!msgs.length) return;
+  if (typeof swal === 'function') {
+    swal({title: 'Mover Tuning thresholds', text: msgs.join('\n\n'), type: 'warning', confirmButtonText: 'OK'});
+  } else {
+    mtNotice('#freeing_notice', msgs.join(' '));
+  }
+}
+
 $(function() {
   updateScreenMoverTuningSettings('<? echo $moverDisabled ?>');
   updateScreenMoverAdvancedSettings('<? echo $advancedSettings ?>');
@@ -245,6 +316,9 @@ $(function() {
   toggleTime('ctime');
   toggleTime('atime');
   toggleAge($('select[name="age"]').val());
+
+  mtRebuildThresholds($('select[name="movingThreshold"]').val());
+  mtWarnSavedThresholds();
 });
 </script>
 
@@ -646,7 +720,7 @@ _(Move Now button follows plug-in filters)_:
 <div class="title"><span class="center"><i class="fa fa-filter title"></i>Mover Tuning - Filters</span></div>
 
 _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
-: <select name="movingThreshold" size="1">
+: <select name="movingThreshold" size="1" onchange="mtRebuildThresholds(this.value)">
 <?for ($t=95;$t>=0;$t-=5):?>
 <?=mk_option($cfg['movingThreshold'], $t, "$t %")?>
 <?endfor;?>
@@ -660,12 +734,13 @@ _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
 </blockquote>
 
 _(Free down/prime up to this level of used Primary (<em>cache</em>) space)_:
-: <select name="freeingThreshold" size="1">
+: <select name="freeingThreshold" size="1" onchange='mtNotice("#freeing_notice","")'>
 <?for ($f=$f;$f>=0;$f-=5):?>
 <?=mk_option($cfg['freeingThreshold'], $f, "$f %")?>
 <?endfor;?>
 </select>
 <span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>Cache → Array</em></span>
+<span id="freeing_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 <blockquote class="inline_help">
 <p> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive after the mover has completed its run. Setting this to (<strong><em> 0% </em></strong>) means that the mover will continue until all data is moved off the cache pool.</p>
@@ -874,11 +949,12 @@ _(Move All from Primary->Secondary (cache:yes) shares when disk is above a certa
 </blockquote>
 
 _(Move All from Primary->Secondary shares pool percentage)_:
-: <select name="omoverthresh" size="1" class='myomthresh' <?=$omoverthreshDisabled?>>
+: <select name="omoverthresh" size="1" class='myomthresh' <?=$omoverthreshDisabled?> onchange='mtNotice("#omoverthresh_notice","")'>
 <?for ($om;$om<=100;$om+=5):?>
 <?=mk_option($cfg['omoverthresh'], $om, "$om %")?>
 <?endfor;?>
 </select>
+<span id="omoverthresh_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 <blockquote class="inline_help">
 <p>Set to the amount of disk space used on the Primary pool to initiate a move of all files in a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share.</p>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -317,8 +317,12 @@ $(function() {
   toggleTime('atime');
   toggleAge($('select[name="age"]').val());
 
-  mtRebuildThresholds($('select[name="movingThreshold"]').val());
-  mtWarnSavedThresholds();
+  // the share page omits these selects for cache:prefer and unavailable shares
+  var $moving = $('select[name="movingThreshold"]');
+  if ($moving.length) {
+    mtRebuildThresholds($moving.val());
+    mtWarnSavedThresholds();
+  }
 });
 </script>
 

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
@@ -34,8 +34,9 @@ $sparsnessfDisabled = ($cfg['sparsnessf'] != "yes") ? "disabled" : "";
 $filetypesfDisabled = ($cfg['filetypesf'] != "yes") ? "disabled" : "";
 $filelistfDisabled = ($cfg['filelistf'] != "yes") ? "disabled" : "";
 $omoverthreshDisabled = ($cfg['omovercfg'] != "yes") ? "disabled" : "";
-$om = $cfg['movingThreshold']; $om = $om + 5;
-$f = $cfg['movingThreshold'];
+$movingSaved = (int)($cfg['movingThreshold'] ?? 0);
+$om = $movingSaved + 5;
+$f = $movingSaved;
 
 ?>
 
@@ -52,6 +53,76 @@ $.fn.toggleAttr = function(attr) {
 	});
 }
 
+// What the config holds, before the selects below capped it to a range.
+var mtSaved = {
+  moving:   <?=(int)($cfg['movingThreshold'] ?? 0)?>,
+  freeing:  <?=(int)($cfg['freeingThreshold'] ?? 0)?>,
+  omover:   <?=strlen((string)($cfg['omoverthresh'] ?? '')) ? (int)$cfg['omoverthresh'] : 'null'?>,
+  omoverOn: <?=(($cfg['omovercfg'] ?? '') == 'yes') ? 'true' : 'false'?>
+};
+
+// Refills one select over [from..to]. Returns '' when the current value survived, else the
+// value it was clamped to.
+function mtFillRange(sel, from, to, step) {
+  var $sel = $(sel);
+  if (!$sel.length) return '';
+  if (step > 0 && from > to) from = to;
+  if (step < 0 && from < to) from = to;
+  var prev = $sel.val(), html = '', keep = false;
+  for (var v = from; step > 0 ? v <= to : v >= to; v += step) {
+    html += '<option value="' + v + '">' + v + ' %</option>';
+    if (String(v) === prev) keep = true;
+  }
+  $sel.html(html);
+  $sel.val(keep ? prev : $sel.find('option').first().val());
+  return keep ? '' : $sel.val();
+}
+
+function mtNotice(id, text) {
+  var $n = $(id);
+  if (!$n.length) return;
+  if (text) $n.html('<i class="fa fa-warning"></i> ' + text).show(); else $n.hide();
+}
+
+// Both ranges are derived from the moving threshold, so a range left over from an older
+// moving value would save a number nobody picked.
+function mtRebuildThresholds(moving) {
+  moving = parseInt(moving, 10) || 0;
+
+  var freeing = mtFillRange('select[name="freeingThreshold"]', moving, 0, -5);
+  mtNotice('#freeing_notice', freeing ? 'Freeing threshold lowered to ' + freeing +
+    '% to stay at or below the moving threshold.' : '');
+
+  var $om = $('select[name="omoverthresh"]');
+  var omover = mtFillRange($om, moving + 5, 100, 5);
+  mtNotice('#omoverthresh_notice', (omover && !$om.prop('disabled')) ?
+    'Move All threshold raised to ' + omover + '% to stay above the moving threshold.' : '');
+}
+
+// A config saved before the ranges tracked each other can hold a combination this page cannot
+// show, so it would display one value and store another until the next save.
+function mtWarnSavedThresholds() {
+  var msgs = [];
+  if (mtSaved.freeing > mtSaved.moving) {
+    msgs.push('The saved freeing threshold is ' + mtSaved.freeing + '%, above the moving threshold of ' +
+      mtSaved.moving + '%. The mover starts at ' + mtSaved.moving + '% and stops at ' + mtSaved.freeing +
+      '%, so nothing is moved while the pool sits between them. This page now shows ' +
+      $('select[name="freeingThreshold"]').val() + '%, and saving will store that.');
+  }
+  if (mtSaved.omoverOn && mtSaved.omover !== null && mtSaved.omover <= mtSaved.moving) {
+    msgs.push('The saved Move All threshold is ' + mtSaved.omover + '%, at or below the moving threshold ' +
+      'of ' + mtSaved.moving + '%. Everything on cache:yes shares moves, skip list and filters ignored, ' +
+      'before the moving threshold is reached. This page now shows ' +
+      $('select[name="omoverthresh"]').val() + '%, and saving will store that.');
+  }
+  if (!msgs.length) return;
+  if (typeof swal === 'function') {
+    swal({title: 'Mover Tuning thresholds', text: msgs.join('\n\n'), type: 'warning', confirmButtonText: 'OK'});
+  } else {
+    mtNotice('#freeing_notice', msgs.join(' '));
+  }
+}
+
 function updateScreenMoverTuning(option,slow) {
   switch (option) {
   case 'no':
@@ -64,6 +135,9 @@ function updateScreenMoverTuning(option,slow) {
 }
 $(function() {
   updateScreenMoverTuning('<? echo $overrideEnabled ?>');
+
+  mtRebuildThresholds($('select[name="movingThreshold"]').val());
+  mtWarnSavedThresholds();
 });
 </script>
 
@@ -269,7 +343,7 @@ _(Override Mover Tuning settings for this share)_:
 
 <div markdown="1" id="moverSettings">
 _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
-: <select name="movingThreshold" size="1">
+: <select name="movingThreshold" size="1" onchange="mtRebuildThresholds(this.value)">
 <?for ($t=0;$t<100;$t+=5):?>
 <?=mk_option($cfg['movingThreshold'], $t, "$t %")?>
 <?endfor;?>
@@ -278,11 +352,12 @@ _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
 > Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive for mover to run. When this threshold is reached, the mover will start running to move data off the cache pool.
 
 _(Free down to this level of used Primary (<em>cache</em>) space)_:
-: <select name="freeingThreshold" size="1">
+: <select name="freeingThreshold" size="1" onchange='mtNotice("#freeing_notice","")'>
 <?for ($f=$f;$f>=0;$f-=5):?>
 <?=mk_option($cfg['freeingThreshold'], $f, "$f %")?>
 <?endfor;?>
 </select>
+<span id="freeing_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 > Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive after the mover has completed its run. Setting this to (<strong><em> 0% </em></strong>) means that the mover will continue until all data is moved off the cache pool.
 
@@ -469,11 +544,12 @@ _(Move All from Primary->Secondary (cache:yes) shares when disk is above a certa
 </blockquote>
 
 _(Move All from Primary->Secondary (cache:yes) shares pool percentage)_:
-: <select name="omoverthresh" size="1" class='myomthresh' <?=$omoverthreshDisabled?>>
+: <select name="omoverthresh" size="1" class='myomthresh' <?=$omoverthreshDisabled?> onchange='mtNotice("#omoverthresh_notice","")'>
 <?for ($om;$om<=100;$om+=5):?>
 <?=mk_option($cfg['omoverthresh'], $om, "$om %")?>
 <?endfor;?>
 </select>
+<span id="omoverthresh_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 <blockquote class="inline_help">
 <p>Set to the amount of disk space used on the Primary pool to initiate a move of all files in a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share.</p>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
@@ -136,8 +136,12 @@ function updateScreenMoverTuning(option,slow) {
 $(function() {
   updateScreenMoverTuning('<? echo $overrideEnabled ?>');
 
-  mtRebuildThresholds($('select[name="movingThreshold"]').val());
-  mtWarnSavedThresholds();
+  // the share page omits these selects for cache:prefer and unavailable shares
+  var $moving = $('select[name="movingThreshold"]');
+  if ($moving.length) {
+    mtRebuildThresholds($moving.val());
+    mtWarnSavedThresholds();
+  }
 });
 </script>
 


### PR DESCRIPTION
What @masterwishx asked for in https://github.com/masterwishx/ca.mover.tuning/pull/182#issuecomment-5561734271 — stop the moving threshold being set below the freeing threshold. Also the UI half deferred by #169.

## The bug

The freeing and Move All selects take their range from the moving threshold, but only at render time and only from the **saved** value (`$f = $cfg['movingThreshold']`). Neither had an `onchange`, so lowering the moving threshold and saving sent the stale dependent value with it. `mk_option` marks an option `selected` only on an exact match, so once the config holds a value the range no longer offers, nothing is selected and the browser shows the first option — the page displays one number and stores another.

| saved | freeing shows | Move All shows |
|---|---|---|
| 55 / 25 / 90 | 25 | 90 |
| moving **20**, freeing 25 | **20** | 90 |
| moving 55, Move All **50** | 25 | **60** |

Freeing above moving means nothing moves while the pool sits between them. Move All at or below moving is worse and had no warning at all — `age_mover:1176` tests it *before* the moving threshold at `:1179`, and Move All ignores every filter including the skip list, so everything leaves cache below the threshold the page shows.

## The fix

Both ranges rebuild from the live moving threshold, so the pair cannot be saved wrong. A value that no longer fits is clamped and says so inline, in the existing test-mode warning style; the notice clears once the user picks a value themselves.

![freeing threshold clamped](https://raw.githubusercontent.com/chodeus/ca.mover.tuning/threshold-ui-screenshots/screenshots/01-live-clamp-freeing-threshold.jpg)

![Move All threshold clamped](https://raw.githubusercontent.com/chodeus/ca.mover.tuning/threshold-ui-screenshots/screenshots/02-live-clamp-move-all-threshold.jpg)

A config saved before this can hold a combination the page cannot show, so one modal states what is stored, what is displayed now, and what saving will write. Both problems share one modal — SweetAlert shows one at a time. Suppressed when *Move All* is off.

![warning modal](https://raw.githubusercontent.com/chodeus/ca.mover.tuning/threshold-ui-screenshots/screenshots/03-warning-freeing-above-moving.jpg)

![both thresholds flagged](https://raw.githubusercontent.com/chodeus/ca.mover.tuning/threshold-ui-screenshots/screenshots/04-warning-both-thresholds.jpg)

Presentation only: no `age_mover` change, no config format change, and its warnings stay as the backstop for a hand-edited config. Seeds are cast to `int` — an empty `movingThreshold` made `"" + 5` a `TypeError` on PHP 8 and took the whole Mover Tuning block off the page.

## Testing

7.3.2 / PHP 8.4.23. Drove the moving threshold through every value 0–95 on both pages, reading the dependents back after each: `freeing > moving` and `Move All <= moving` never occurred. Each modal case driven from a real config file; a healthy config produces no modal, and the Move All half stays silent when *Move All* is off. Share page keeps its ascending order, and skips init on cache:prefer and unavailable shares where the selects are not rendered. Config restored byte-identical afterwards and a mover run still reads 55 / 25 / 90.

`php -l` clean under 7.4 and 8.4 with `short_open_tag=1` — nothing beyond `(int)`, `??` and `strlen`, so the 6.9 floor holds. SweetAlert 1.x API, feature-detected, falling back to the inline notice. No new file, dependency or packaging change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Threshold dropdowns on the mover and share settings pages now update dynamically when the moving threshold changes.
  - Available options are constrained so freeing thresholds stay at or below the moving threshold, while Move All thresholds stay above it.
  - Previously saved values outside the valid ranges are adjusted and clearly flagged with warnings.
  - Threshold controls refresh immediately when related settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
