### PR TITLE
Multi-language support for the settings and share pages

### DIFF
--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -991,7 +991,7 @@ _(Move files off Primary (cache) based on sparseness)_?
 
 :end
 
-_(Move files that are greather than this sparseness)_:
+_(Move files that are greater than this sparseness)_:
 : <select name="sparsnessv" size="1" class='mysparsnessf' <?=$sparsnessfDisabled?>>
 	<?=mk_option($cfg['sparsnessv'], 1, ".1")?>
 	<?=mk_option($cfg['sparsnessv'], 2, ".2")?>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -4,9 +4,9 @@ Tag="gear"
 ---
 <?PHP
 if ($var['shareCacheEnabled']!='yes') {
-  echo "<p class='notice'>Cache disk not enabled!</p>";
+  echo "<p class='notice'>"._('Cache disk not enabled!')."</p>";
 } elseif ($var['shareUser']=='-') {
-  echo "<p class='notice'>User shares not enabled!</p>";
+  echo "<p class='notice'>"._('User shares not enabled!')."</p>";
 }
 $vars = @parse_ini_file("/var/local/emhttp/var.ini") ?: [];
 $plugin = 'ca.mover.tuning';
@@ -261,6 +261,12 @@ function mtFillRange(sel, from, to, step) {
   return keep ? '' : $sel.val();
 }
 
+// %1, %2... in a translated template are filled from the extra arguments.
+function mtFmt(tpl) {
+  var args = arguments;
+  return tpl.replace(/%(\d)/g, function(m, i) { return args[i]; });
+}
+
 function mtNotice(id, text) {
   var $n = $(id);
   if (!$n.length) return;
@@ -273,13 +279,13 @@ function mtRebuildThresholds(moving) {
   moving = parseInt(moving, 10) || 0;
 
   var freeing = mtFillRange('select[name="freeingThreshold"]', moving, 0, -5);
-  mtNotice('#freeing_notice', freeing ? 'Freeing threshold lowered to ' + freeing +
-    '% to stay at or below the moving threshold.' : '');
+  mtNotice('#freeing_notice', freeing ?
+    mtFmt('_(Freeing threshold lowered to %1 to stay at or below the moving threshold.)_', freeing + '%') : '');
 
   var $om = $('select[name="omoverthresh"]');
   var omover = mtFillRange($om, moving + 5, 100, 5);
   mtNotice('#omoverthresh_notice', (omover && !$om.prop('disabled')) ?
-    'Move All threshold raised to ' + omover + '% to stay above the moving threshold.' : '');
+    mtFmt('_(Move All threshold raised to %1 to stay above the moving threshold.)_', omover + '%') : '');
 }
 
 // A config saved before the ranges tracked each other can hold a combination this page cannot
@@ -287,20 +293,16 @@ function mtRebuildThresholds(moving) {
 function mtWarnSavedThresholds() {
   var msgs = [];
   if (mtSaved.freeing > mtSaved.moving) {
-    msgs.push('The saved freeing threshold is ' + mtSaved.freeing + '%, above the moving threshold of ' +
-      mtSaved.moving + '%. The mover starts at ' + mtSaved.moving + '% and stops at ' + mtSaved.freeing +
-      '%, so nothing is moved while the pool sits between them. This page now shows ' +
-      $('select[name="freeingThreshold"]').val() + '%, and saving will store that.');
+    msgs.push(mtFmt('_(The saved freeing threshold is %1, above the moving threshold of %2. The mover starts at %2 and stops at %1, so nothing is moved while the pool sits between them. This page now shows %3, and saving will store that.)_',
+      mtSaved.freeing + '%', mtSaved.moving + '%', $('select[name="freeingThreshold"]').val() + '%'));
   }
   if (mtSaved.omoverOn && mtSaved.omover !== null && mtSaved.omover <= mtSaved.moving) {
-    msgs.push('The saved Move All threshold is ' + mtSaved.omover + '%, at or below the moving threshold ' +
-      'of ' + mtSaved.moving + '%. Everything on cache:yes shares moves, skip list and filters ignored, ' +
-      'before the moving threshold is reached. This page now shows ' +
-      $('select[name="omoverthresh"]').val() + '%, and saving will store that.');
+    msgs.push(mtFmt('_(The saved Move All threshold is %1, at or below the moving threshold of %2. Everything on cache:yes shares moves, skip list and filters ignored, before the moving threshold is reached. This page now shows %3, and saving will store that.)_',
+      mtSaved.omover + '%', mtSaved.moving + '%', $('select[name="omoverthresh"]').val() + '%'));
   }
   if (!msgs.length) return;
   if (typeof swal === 'function') {
-    swal({title: 'Mover Tuning thresholds', text: msgs.join('\n\n'), type: 'warning', confirmButtonText: 'OK'});
+    swal({title: '_(Mover Tuning thresholds)_', text: msgs.join('\n\n'), type: 'warning', confirmButtonText: '_(OK)_'});
   } else {
     mtNotice('#freeing_notice', msgs.join(' '));
   }
@@ -330,7 +332,7 @@ $(function() {
 <span id="mover_schedule_warning" class="orange-text" 
       style="display:<?= (!empty($vars['shareMoverSchedule']) && version_compare($vars['version'], '7.2.1', '>=')) ? 'block' : 'none' ?>; font-style:italic;">
     <i class="fa fa-warning"></i>
-    <?= _('Unraid Mover schedule is currently') ?> <b>enabled</b>
+    <?= _('Unraid Mover schedule is currently **enabled**') ?>
     (<?= htmlspecialchars($vars['shareMoverSchedule']) ?>). &nbsp;
     <?= _('If you want Mover Tuning to fully manage scheduling, disable it in Mover Settings.') ?>
 </span>
@@ -349,7 +351,7 @@ $(function() {
             font-size:1.5rem;
             line-height:1.5em;">
     <i class="fa fa-info-circle" style="margin-right:5px;"></i>
-    <?= _('**Important: &nbsp;*Starting with Unraid 7.2.1, Mover Tuning plugin behavior has changed:***') ?>
+    <b><?= _('Important') ?>:&nbsp;<i><?= _('Starting with Unraid 7.2.1, Mover Tuning plugin behavior has changed') ?>:</i></b>
     <br><br>
     <?= _('• The plugin is now separated from the built-in Unraid mover.') ?>
     <br>
@@ -371,7 +373,7 @@ $(function() {
     <span id="close_mover_notice"
       class="fa fa-times"
       style="position:absolute; top:5px; right:10px; cursor:pointer; font-size:1.3rem;"
-      title="Close"></span>
+      title="_(Close)_"></span>
 </div>
 
 <script>
@@ -419,7 +421,7 @@ $newYearSeason = ($month == 12) ? $year + 1 : $year;
   <?= _('Thank you for using this plugin.') ?><br>
   <?= _('Wishing you a stable array, fast mover runs, and zero parity errors!') ?>
   <div style="opacity:.7;">
-  <span class="plugin-year" data-start="2025"></span> - by <a href="https://forums.unraid.net/profile/107418-masterwishx/" target="_blank" rel="noopener noreferrer"> masterwishx</a>
+  <span class="plugin-year" data-start="2025"></span> - _(by)_ <a href="https://forums.unraid.net/profile/107418-masterwishx/" target="_blank" rel="noopener noreferrer"> masterwishx</a>
   </div>
 
   <!-- Close button -->
@@ -447,8 +449,8 @@ if (localStorage.getItem(newYearSeasonKey) === 'yes') {
 
 
 <div class="title">
-<span class="left"><i class="fa fa-cog title"></i>Mover Tuning - Plugin Settings</span>
-<span class="right">Version: <?=$version?></span>
+<span class="left"><i class="fa fa-cog title"></i>_(Mover Tuning - Plugin Settings)_</span>
+<span class="right">_(Version)_: <?=$version?></span>
 </div>
 
 <div class='moverUpdate'></div>
@@ -460,18 +462,22 @@ _(Disable Mover running on a schedule)_:
 <?=mk_option($cfg['moverDisabled'],"no",_('No'))?>
 <?=mk_option($cfg['moverDisabled'],"yes",_('Yes'))?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>Yes</strong> <em>- disables the plugin's schedule</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>_(Yes)_</strong> <em>- _(disables the plugin's schedule)_</em></span>
 
-:mover_tune_disable_plug:
-<blockquote class="inline_help">
 <?php if (version_compare($vars['version'] ?? '0.0.0', '7.2.1', '>=')): ?>
+<blockquote class="inline_help">
+:mover_tune_disable_plug:
 <p>This will <strong>prevent</strong> mover from running at the schedule set in <strong>Mover Tuning Settings</strong>.</p>
 <p>You will only be able to run mover by <strong>manually</strong> invoking it:</p>
 <ul>
   <li>Press the <strong>“Move now”</strong> button in <strong>Mover Tuning - Options</strong>.</li>
   <li>Run <strong>“age_mover start”</strong> from the <strong>CLI</strong>.</li>
 </ul>
+:end
+</blockquote>
 <?php else: ?>
+<blockquote class="inline_help">
+:mover_tune_disable_legacy_plug:
 <p>This will <strong>prevent</strong> mover from running at the schedule set in <strong>Mover Settings</strong>.</p>
 <p>You will only be able to run mover by <strong>manually</strong> invoking it:</p>
 <ul>
@@ -479,19 +485,23 @@ _(Disable Mover running on a schedule)_:
   <li>Press <strong>“Move”</strong> on the <strong>Main</strong> page.</li>
   <li>Run <strong>“mover start”</strong> from the <strong>CLI</strong>.</li>
 </ul>
-<?php endif; ?>
-</blockquote>
 :end
+</blockquote>
+<?php endif; ?>
 
 <div markdown="1" id="moverTuningSettings">
 <?php if (version_compare($vars['version'], '7.2.1', '>=')): ?>
 _(Mover Tuning schedule)_:
 : <input type='text' id='tune_cronSchedule' name='moverTuneCron' size='1' class='tune_mycron' placeholder='0 */4 * * *' value='<?=htmlspecialchars($cfg['moverTuneCron'])?>'>
 
-<blockquote class="inline_help">
-<p>Runs the <strong><code>age_mover</code></strong> schedule from the Mover Tuning plugin using your custom cron entry (includes all plugin filters).</p>
-<p> Cron Schedule entry example <strong>0 */4 * * *</strong>.&nbsp; To run at <em>every</em><strong> 4 hours</strong>.&nbsp; <a href="https://crontab.guru/" target="_blank" rel="noopener noreferrer"><i class="fa fa-clock-o"></i> What Is Cron</a></p>
-</blockquote>
+:mover_tune_movertunecron_plug:
+
+> Runs the <strong><code>age_mover</code></strong> schedule from the Mover Tuning plugin using your custom cron entry (includes all plugin filters).
+>
+> Cron Schedule entry example <strong>0 */4 * * *</strong>.&nbsp; To run at <em>every</em><strong> 4 hours</strong>.&nbsp; <a href="https://crontab.guru/" target="_blank" rel="noopener noreferrer"><i class="fa fa-clock-o"></i> What Is Cron</a>
+
+:end
+
 <?php endif; ?>
 
 _(Test Mode (dry run))_:
@@ -499,7 +509,7 @@ _(Test Mode (dry run))_:
   <?=mk_option($cfg['testmode'],"no",_('No'))?>
   <?=mk_option($cfg['testmode'],"yes",_('Yes'))?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>No</strong> <em>- disables test mode</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>_(No)_</strong> <em>- _(disables test mode)_</em></span>
 <span id="testmode_warning" class="orange-text" style="display:<?= ($cfg['testmode'] == 'yes') ? 'block' : 'none' ?>; font-style:italic;">
   <i class="fa fa-warning"></i> <?= _('Test Mode - no files will be moved/synced.') ?></span>
 
@@ -509,22 +519,22 @@ function toggleTestModeWarning(val) {
 }
 </script>
 
-:mover_tune_testmode_plug:
 <blockquote class="inline_help">
+:mover_tune_testmode_plug:
 <p> Test Mode will <strong>Not</strong> run mover but will output the custom find command results to <em>/tmp/ca.mover.tuning/</em>.</p>
 <p> Caution - If you have "Move Now button follows plug-in filters" set to <strong>No</strong>, original Mover will still run.</p>
-</blockquote>
 :end
+</blockquote>
 
 _(Validate input filenames to prevent attacks)_:
 : <select name='validateFilenames' size='1' onchange="updateScreenMoverInvalidCharsToBlock(this.value, 'slow')">
-<?=mk_option($cfg['validateFilenames'],"yes","Yes")?>
-<?=mk_option($cfg['validateFilenames'],"no",'No')?>
+<?=mk_option($cfg['validateFilenames'],"yes",_('Yes'))?>
+<?=mk_option($cfg['validateFilenames'],"no",_('No'))?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>No</strong> <em>- disables validation of input filenames</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>_(No)_</strong> <em>- _(disables validation of input filenames)_</em></span>
 
-:mover_tune_validate_plug:
 <blockquote class="inline_help">
+:mover_tune_validate_plug:
 <p> <strong><em>In cybersecurity, filenames can be a critical vector for potential attacks and system vulnerabilities. Unsanitized filenames pose significant risks that can compromise system integrity and security.</em></strong></p>
 <p> Validate input filenames will check every filename before it is processed by the Mover. This ensures that <strong>only valid</strong> filenames are accepted, <strong>reducing the risk</strong> of attacks and vulnerabilities.</p>
 <p> Disable <strong>Only</strong> if you have many files to move and you are <strong>sure</strong> that all filenames are <strong>valid</strong> and do not contain any potential security risks.</p>
@@ -533,14 +543,15 @@ _(Validate input filenames to prevent attacks)_:
 (<strong><em> $ </em></strong>), (<strong><em> / </em></strong>), (<strong><em> < </em></strong>), (<strong><em> > </em></strong>), (<strong><em> : </em></strong>), (<strong><em> " </em></strong>), (<strong><em> | </em></strong>), (<strong><em> ? </em></strong>), (<strong><em> * </em></strong>).</p>
 <p> 3. <strong>Prevent path traversal</strong> - The filename should not contain any characters that can be used to traverse directories, such as (<strong><em> ../ </em></strong>).</p>
 <p> If one of these checks fails, the filename will be rejected.</p>
-</blockquote>
 :end
+</blockquote>
 
 <div markdown="1" id="moverInvalidCharsToBlock">
 _(Invalid characters to block)_:
 : <input type='text' name='invalidFileChars' size='1' class='myinvalidFileChars' placeholder='$ / < > : " | ? *' value='<?=htmlspecialchars($cfg['invalidFileChars'])?>'>
 
 <blockquote class="inline_help">
+:mover_tune_invalidfilechars_plug:
 <p> The filename characters such as:
   <strong><em>$</em></strong>
   <strong><em>/</em></strong>
@@ -552,55 +563,66 @@ _(Invalid characters to block)_:
   <strong><em>?</em></strong>
   <strong><em>*</em></strong>.
 </p>
+:end
 </blockquote>
 </div>
 
 _(Log Mover Tuning plugin actions)_:
 : <select name='logging' size='1'>
-<?=mk_option($cfg['logging'],"no",'No')?>
-<?=mk_option($cfg['logging'],"yes","File (and Syslog)")?>
-<?=mk_option($cfg['logging'],"fileOnly","File Only") ?>
+<?=mk_option($cfg['logging'],"no",_('No'))?>
+<?=mk_option($cfg['logging'],"yes",_('File (and Syslog)'))?>
+<?=mk_option($cfg['logging'],"fileOnly",_('File Only')) ?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_logging_plug:
 <p> Enables or disables logging from this plugin.</p>
 <p><strong>File (and Syslog)</strong> will store to <strong>SYSLOG</strong> and to the log file.</p>
 <p><strong>File Only</strong> will store <strong>only</strong> to the log file.</p>
 <p> Logs are displayed in <strong>SYSLOG</strong> and stored at <strong><em>/tmp/ca.mover.tuning/Mover_tuning_xxx.log</em></strong> by default.</p>
+:end
 </blockquote>
 
 _(Debug Log Mover Tuning plugin actions)_:
 : <select name='debuglogging' size='1'>
-<?=mk_option($cfg['debuglogging'],"no",'No')?>
-<?=mk_option($cfg['debuglogging'],"yes","File (and Syslog)")?>
-<?=mk_option($cfg['debuglogging'],"fileOnly","File Only") ?>
+<?=mk_option($cfg['debuglogging'],"no",_('No'))?>
+<?=mk_option($cfg['debuglogging'],"yes",_('File (and Syslog)'))?>
+<?=mk_option($cfg['debuglogging'],"fileOnly",_('File Only')) ?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_debuglogging_plug:
 <p> Enables or disables debug logging from this plugin.</p>
 <p><strong>File (and Syslog)</strong> will store to <strong>SYSLOG</strong> and to the log file.</p>
 <p><strong>File Only</strong> will store <strong>only</strong> to the log file.</p>
 <p> Debug Logs are displayed in <strong>SYSLOG</strong> and stored at <strong><em>/tmp/ca.mover.tuning/Debug_Mover_tuning_xxx.log</em></strong> by default.</p>
+:end
 </blockquote>
 
 _(Notify Mover Tuning plugin actions)_:
 : <select name='notify' size='1'>
-<?=mk_option($cfg['notify'],"no",'No')?>
-<?=mk_option($cfg['notify'],"yes","Yes")?>
-<?=mk_option($cfg['notify'],"errorsOnly","Errors Only")?>
-<?=mk_option($cfg['notify'],"movedOnly","Moved Only")?>
+<?=mk_option($cfg['notify'],"no",_('No'))?>
+<?=mk_option($cfg['notify'],"yes",_('Yes'))?>
+<?=mk_option($cfg['notify'],"errorsOnly",_('Errors Only'))?>
+<?=mk_option($cfg['notify'],"movedOnly",_('Moved Only'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_notify_plug:
 <p>Enables or disables notifications from this plugin. Notifications are displayed in Unriad GUI.</p>
 <p><strong>Errors Only</strong> will send a notification <strong>only</strong> when an error occurs.</p>
 <p><strong>Moved Only</strong> will send a notification <strong>only</strong> when files are moved or when an error occurs, not every time the mover is running.</p>
+:end
 </blockquote>
 
 _(Logs parent folder for Mover Tuning plugin)_:
 : <input type='text' name='loggingFolder' size='1' class='loggingFolder' placeholder='/tmp' value='<?=htmlspecialchars($cfg['loggingFolder'])?>'>
 
+:mover_tune_loggingfolder_plug:
+
 > Path to a parent Logs folder <strong><em>/tmp</em></strong>. Logs are stored at this parent path, by default at <strong><em>/tmp/ca.mover.tuning</em></strong>.
+
+:end
 
 _(Delete Mover Log files over than this days old)_:
 : <select name="logfilesDaysold" size="1" class='logfilesDaysold' value='<?=$cfg['logfilesDaysold']?>'>
@@ -618,7 +640,11 @@ _(Delete Mover Log files over than this days old)_:
 <?endfor;?>
 </select>
 
+:mover_tune_logfilesdaysold_plug:
+
 > Select the number of **days old** for Mover Tuning plugin to delete log files **_*.log_** and text files **_*.txt_**.
+
+:end
 
 _(Delete Mover helper files over than this days old)_:
 : <select name="listfilesDaysold" size="1" class='listfilesDaysold' value='<?=$cfg['listfilesDaysold']?>'>
@@ -636,92 +662,128 @@ _(Delete Mover helper files over than this days old)_:
 <?endfor;?>
 </select>
 
+:mover_tune_listfilesdaysold_plug:
+
 > Select the number of **days old** for Mover Tuning plugin to delete list files **<em>*.list</em>**.
+
+:end
 
 _(Show advanced settings)_:
 : <select name='advancedSettings' size='1' onchange="updateScreenMoverAdvancedSettings(this.value, 'slow')">
-<?=mk_option($cfg['advancedSettings'],"no","No")?>
-<?=mk_option($cfg['advancedSettings'],"yes","Yes")?>
+<?=mk_option($cfg['advancedSettings'],"no",_('No'))?>
+<?=mk_option($cfg['advancedSettings'],"yes",_('Yes'))?>
 </select>
 
+:mover_tune_advancedsettings_plug:
+
 > Show advanced settings options. Please note that these settings are active if set even if not shown.
+
+:end
 
 <div markdown="1" id="moverAdvancedSettings">
 _(Let scheduled mover run during a parity check / rebuild)_:
 : <select name='parity' size='1'>
-  <?=mk_option($cfg['parity'],'yes','Yes')?>
-  <?=mk_option($cfg['parity'],'no','No')?>
+  <?=mk_option($cfg['parity'],'yes',_('Yes'))?>
+  <?=mk_option($cfg['parity'],'no',_('No'))?>
 </select>
+
+:mover_tune_parity_plug:
 
 > If a parity check or disk rebuild is in progress, this will prevent mover from running.
 
+:end
+
 _(Priority for mover process)_:
 : <select name='moverNice' size='1'>
-<?=mk_option($cfg['moverNice'],"0","Normal")?>
-<?=mk_option($cfg['moverNice'],"5","Low")?>
-<?=mk_option($cfg['moverNice'],"19","Very Low")?>
+<?=mk_option($cfg['moverNice'],"0",_('Normal'))?>
+<?=mk_option($cfg['moverNice'],"5",_('Low'))?>
+<?=mk_option($cfg['moverNice'],"19",_('Very Low'))?>
 </select>
 
 _(Priority for disk I/O)_:
 : <select name='moverIO' size='1'>
-<?=mk_option($cfg['moverIO'],"-c 2 -n 0","Normal")?>
-<?=mk_option($cfg['moverIO'],"-c 2 -n 7","Low")?>
-<?=mk_option($cfg['moverIO'],"-c 3","Idle")?>
+<?=mk_option($cfg['moverIO'],"-c 2 -n 0",_('Normal'))?>
+<?=mk_option($cfg['moverIO'],"-c 2 -n 7",_('Low'))?>
+<?=mk_option($cfg['moverIO'],"-c 3",_('Idle'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_moverio_plug:
 <p>The above two options set the priority for the mover process.</p>
 <p>Setting these options may help with circumstances where when mover runs other applications may pause or buffer.</p>
 <p>Note that moving the files may take <strong>longer</strong> when setting these options.</p>
+:end
 </blockquote>
 
 _(Force move of all files on a schedule)_:
 : <select name='force' size='1' id='forceCron' onchange='$(".mycron").toggleAttr("disabled")'>
-<?=mk_option($cfg['force'],"no",'No')?>
-<?=mk_option($cfg['force'],"yes","Yes")?>
+<?=mk_option($cfg['force'],"no",_('No'))?>
+<?=mk_option($cfg['force'],"yes",_('Yes'))?>
 </select>
 
+:mover_tune_force_plug:
+
 > Select <strong>Yes</strong> to run <strong>original mover</strong> on a custom cron schedule (ignores plugin filters).
+
+:end
 
 _(Cron Schedule to force move all of files)_:
 : <input type='text' id='cronSchedule' name='cron' size='1' class='mycron' placeholder='20 4 1 * *' value='<?=htmlspecialchars($cfg['cron'])?>' <?=$cronDisabled?>>
 
+:mover_tune_cron_plug:
+
 > Cron Schedule entry example <strong>20 4 1 * *</strong>.&nbsp; To run the <em>first day of the month at </em><strong>4:20 AM</strong>.&nbsp; <a href="https://crontab.guru/" target="_blank" rel="noopener noreferrer"><i class="fa fa-clock-o"></i> What Is Cron</a> 
+
+:end
 
 _(Allow force mover schedule to run during a parity check/rebuild)_:
 : <select name='forceParity' size='1' class='mycron' <?=$cronDisabled?>>
-<?=mk_option($cfg['forceParity'],"yes","Yes")?>
-<?=mk_option($cfg['forceParity'],"no","No")?>
+<?=mk_option($cfg['forceParity'],"yes",_('Yes'))?>
+<?=mk_option($cfg['forceParity'],"no",_('No'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_forceparity_plug:
 <p>Setting a cron schedule to force a move will run mover on that schedule.</p>
 <p>Example: In Mover Settings you would have a schedule of Hourly. During that schedule the rules above are followed.</p>
 <p>The cron schedule for a force move could be set to <strong>30 03 * * *</strong> which would force all files to be moved at <strong>3:30 AM</strong> every day regardless of the rules</p>
 <p>The forceParity setting allows you to override this behavior and force all files to be moved regardless of the rules.</p>
 <p>Note that no error checking is done on the cron schedule. It must be a valid entry.</p>
+:end
 </blockquote>
 
 _(Script to run before mover (No checks, always runs))_:
 : <input type='text' name='beforeScript' size='1' class='mybefore' placeholder='/mnt/user/Files/script_before_mover.sh' value='<?=htmlspecialchars($cfg['beforeScript'])?>'>
 
+:mover_tune_beforescript_plug:
+
 > Path to a script that will be run before mover starts.  This script will always be run even if the filters don't find anything to move.
+
+:end
 
 _(Script to run after mover (No checks, always runs))_:
 : <input type='text' name='afterScript' size='1' class='myafter' placeholder='/mnt/user/Files/script_after_mover.sh' value='<?=htmlspecialchars($cfg['afterScript'])?>'>
 
+:mover_tune_afterscript_plug:
+
 > Path to a script that will be run after mover finishes.  This script will always be run.
+
+:end
 
 _(Move Now button follows plug-in filters)_:
 : <select name='movenow' size='1' id='movenowbtn'>
-<?=mk_option($cfg['movenow'],"no",'No')?>
-<?=mk_option($cfg['movenow'],"yes","Yes")?>
+<?=mk_option($cfg['movenow'],"no",_('No'))?>
+<?=mk_option($cfg['movenow'],"yes",_('Yes'))?>
 </select>
 
+:mover_tune_movenow_plug:
+
 > Select <strong>Yes</strong> to follow plugin filters, <strong>No</strong> to run original mover (ignores plugin filters) from the button.
+
+:end
 </div>
 
-<div class="title"><span class="center"><i class="fa fa-filter title"></i>Mover Tuning - Filters</span></div>
+<div class="title"><span class="center"><i class="fa fa-filter title"></i>_(Mover Tuning - Filters)_</span></div>
 
 _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
 : <select name="movingThreshold" size="1" onchange="mtRebuildThresholds(this.value)">
@@ -729,12 +791,14 @@ _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
 <?=mk_option($cfg['movingThreshold'], $t, "$t %")?>
 <?endfor;?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>Cache → Array</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>_(Cache → Array)_</em></span>
 
 <blockquote class="inline_help">
+:mover_tune_movingthreshold_plug:
 <p> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive for mover to run. When this threshold is reached, the mover will start running to move data off the cache pool.</p>
 <p> <u>Note:</u> If you observe that the <strong>mover is NOT moving data when it should</strong>, try setting a <strong>higher moving threshold</strong> to increase the gap between the moving and freeing thresholds.</p>
 <p> Mover calculates the sum of the used cache pool size and file size until exceed the freeing threshold. If you have large files, this might result in not fitting within the allocated space for freeing thresholds.</p>
+:end
 </blockquote>
 
 _(Free down/prime up to this level of used Primary (<em>cache</em>) space)_:
@@ -743,13 +807,15 @@ _(Free down/prime up to this level of used Primary (<em>cache</em>) space)_:
 <?=mk_option($cfg['freeingThreshold'], $f, "$f %")?>
 <?endfor;?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>Cache → Array</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>_(Cache → Array)_</em></span>
 <span id="freeing_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 <blockquote class="inline_help">
+:mover_tune_freeingthreshold_plug:
 <p> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive after the mover has completed its run. Setting this to (<strong><em> 0% </em></strong>) means that the mover will continue until all data is moved off the cache pool.</p>
 <p> <u>Note:</u> If you observe that the <strong>mover is NOT moving data when it should</strong>, try setting a <strong>lower freeing threshold</strong> to increase the gap between the moving and freeing thresholds.</p>
 <p> Mover calculates the sum of the used cache pool size and file size until exceed the freeing threshold. If you have large files, this might result in not fitting within the allocated space for freeing thresholds.</p>
+:end
 </blockquote>
 
 _(Fill up/prime up to this level of used Primary (<em>cache</em>) space)_:
@@ -758,21 +824,29 @@ _(Fill up/prime up to this level of used Primary (<em>cache</em>) space)_:
 <?=mk_option($cfg['fillupThreshold'], $c, "$c %")?>
 <?endfor;?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>Array → Cache</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<em>_(Array → Cache)_</em></span>
+
+:mover_tune_fillupthreshold_plug:
 
 > Set to the amount of disk space used on the <strong><em>Secondary->Primary</em></strong> (cache:<strong>prefer</strong>) drive after the mover has completed its run. Setting this to (<strong><em>95%</em></strong>) means that the mover will continue until <strong><em>95%</em></strong> of the cache pool is filled.
 
+:end
+
 _(Move files off Primary (<em>cache</em>) based on age)_?
 : <select name="age" size='1' onchange="toggleAge(this.value)">
-  <?=mk_option($cfg['age'],'no','No')?>
-  <?=mk_option($cfg['age'],'yes','Yes')?>
+  <?=mk_option($cfg['age'],'no',_('No'))?>
+  <?=mk_option($cfg['age'],'yes',_('Yes'))?>
 </select>
+
+:mover_tune_age_plug:
 
 > Select if you want to move files off of the Primary (cache) based on their age - days old.
 
+:end
+
 _(Move files that are greater than this many days old)_:
 : <select name="daysold" size="1" class='myage' <?=$ageDisabled?>>
-<?=mk_option($cfg['daysold'], -1, "Auto")?>
+<?=mk_option($cfg['daysold'], -1, _('Auto'))?>
 <?=mk_option($cfg['daysold'], 1, "1")?>
 <?=mk_option($cfg['daysold'], 2, "2")?>
 <?=mk_option($cfg['daysold'], 3, "3")?>
@@ -786,42 +860,62 @@ _(Move files that are greater than this many days old)_:
 <?=mk_option($cfg['daysold'], $dt, "$dt")?>
 <?endfor;?>
 </select>
-<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>Auto</strong> <em>- enable smart caching</em></span>
+<span><i class="fa fa-info i"></i>&nbsp;&nbsp;<strong>_(Auto)_</strong> <em>- _(enable smart caching)_</em></span>
+
+:mover_tune_daysold_plug:
 
 > Select the number of **days old** a file has to be in order to move (Up To 1 year). Auto will move from the oldest to the most recent, until threshold is met.
 
+:end
+
 _(Show advanced filters)_:
 : <select name='advancedFilters' size='1' onchange="updateScreenMoverAdvancedFilters(this.value, 'slow')">
-<?=mk_option($cfg['advancedFilters'],"no","No")?>
-<?=mk_option($cfg['advancedFilters'],"yes","Yes")?>
+<?=mk_option($cfg['advancedFilters'],"no",_('No'))?>
+<?=mk_option($cfg['advancedFilters'],"yes",_('Yes'))?>
 </select>
 
+:mover_tune_advancedfilters_plug:
+
 > Show advanced filter options. Please note that these filters are active if set even if not shown.
+
+:end
 
 <div markdown="1" id="moverAdvancedFilters">
 _(Use CTIME)_:
 : <select name="ctime" size='1' class='myage ctime' <?=$ageDisabled?> onchange="toggleTime('ctime')">
-  <?=mk_option($cfg['ctime'],'no','No')?>
-  <?=mk_option($cfg['ctime'],'yes','Yes')?>
+  <?=mk_option($cfg['ctime'],'no',_('No'))?>
+  <?=mk_option($cfg['ctime'],'yes',_('Yes'))?>
 </select>
+
+:mover_tune_ctime_plug:
 
 > Use <strong>CTIME</strong> <em>( creation time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
 
+:end
+
 _(Use ATIME)_:
 : <select name="atime" size='1' class='myage atime' <?=$ageDisabled?> onchange="toggleTime('atime')">
-  <?=mk_option($cfg['atime'],'no','No')?>
-  <?=mk_option($cfg['atime'],'yes','Yes')?>
+  <?=mk_option($cfg['atime'],'no',_('No'))?>
+  <?=mk_option($cfg['atime'],'yes',_('Yes'))?>
 </select>
+
+:mover_tune_atime_plug:
 
 > Use <strong>ATIME</strong> <em>( access time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
 
+:end
+
 _(Move files based on minimum size)_?
 : <select name="sizef" size='1' onchange='$(".mysizef").toggleAttr("disabled")'>
-  <?=mk_option($cfg['sizef'],'no','No')?>
-  <?=mk_option($cfg['sizef'],'yes','Yes')?>
+  <?=mk_option($cfg['sizef'],'no',_('No'))?>
+  <?=mk_option($cfg['sizef'],'yes',_('Yes'))?>
 </select>
 
+:mover_tune_sizef_plug:
+
 > Select <strong>yes</strong> if you want to move files based on their size in <strong>MB</strong>.
+
+:end
 
 _(Move files that are larger than this size (In MB))_.
 : <select name="sizeinM" size="1" class='mysizef' <?=$sizefDisabled?>>
@@ -842,15 +936,23 @@ _(Move files that are larger than this size (In MB))_.
 	<?endfor;?>
 </select>
 
+:mover_tune_sizeinm_plug:
+
 > Select the minimum size a file has to be to get moved (in **Megabytes**).
+
+:end
 
 _(Sync files based on maximum size)_?
 : <select name="sizefSync" size='1' onchange='$(".mysizefSync").toggleAttr("disabled")'>
-  <?=mk_option($cfg['sizefSync'],'no','No')?>
-  <?=mk_option($cfg['sizefSync'],'yes','Yes')?>
+  <?=mk_option($cfg['sizefSync'],'no',_('No'))?>
+  <?=mk_option($cfg['sizefSync'],'yes',_('Yes'))?>
 </select>
 
+:mover_tune_sizefsync_plug:
+
 > Select <strong>yes</strong> if you want to sync files based on their size in <strong>MB</strong>. This option is only applicable when the Synchronize or Resynchronize feature is enabled.
+
+:end
 
 _(Sync files that are smaller than this size (In MB))_.
 : <select name="sizeinMSync" size="1" class='mysizefSync' <?=$sizefSyncDisabled?>>
@@ -871,15 +973,23 @@ _(Sync files that are smaller than this size (In MB))_.
 	<?endfor;?>
 </select>
 
+:mover_tune_sizeinmsync_plug:
+
 > Select the maximum size a file has to be to get synched (in **Megabytes**).
+
+:end
 
 _(Move files off Primary (cache) based on sparseness)_?
 : <select name="sparsnessf" size='1' onchange='$(".mysparsnessf").toggleAttr("disabled")'>
-  <?=mk_option($cfg['sparsnessf'],'no','No')?>
-  <?=mk_option($cfg['sparsnessf'],'yes','Yes')?>
+  <?=mk_option($cfg['sparsnessf'],'no',_('No'))?>
+  <?=mk_option($cfg['sparsnessf'],'yes',_('Yes'))?>
 </select>
 
+:mover_tune_sparsnessf_plug:
+
 > Select the sparseness size. Any file with a sparseness larger will be moved.
+
+:end
 
 _(Move files that are greather than this sparseness)_:
 : <select name="sparsnessv" size="1" class='mysparsnessf' <?=$sparsnessfDisabled?>>
@@ -894,18 +1004,23 @@ _(Move files that are greather than this sparseness)_:
 	<?=mk_option($cfg['sparsnessv'], 9, ".9")?>
 </select>
 
+:mover_tune_sparsnessv_plug:
+
 > Select the sparseness size greater than that will be moved.
+
+:end
 
 _(Ignore files and folders listed inside of a text file)_:
 : <select name='filelistf' size='1' onchange='$(".myfilelistf").toggleAttr("disabled")'>
-<?=mk_option($cfg['filelistf'],"no",'No')?>
-<?=mk_option($cfg['filelistf'],"yes","Yes")?>
+<?=mk_option($cfg['filelistf'],"no",_('No'))?>
+<?=mk_option($cfg['filelistf'],"yes",_('Yes'))?>
 </select>
 
 _(File list path)_:
 : <input type='text' name='filelistv' size='1' class='myfilelistf' placeholder='/mnt/user/Files/mover_ignore.txt' value='<?=htmlspecialchars($cfg['filelistv'])?>' <?=$filelistfDisabled?>>
 
 <blockquote class="inline_help">
+:mover_tune_filelistv_plug:
 <p> Full path to a file that contains a list of files and folders you want ignored from being moved off the Primary (cache) pool.</p>
 <p> <strong>File List</strong> example: <strong><em>/mnt/user/Files/mover_ignore.txt</em></strong> , The contents of this file should be one entry per line.</p>
 <p> <strong>Folder</strong> example: <strong><em>/mnt/cache_ssd/Files/MyFolder</em></strong> , Do <strong>NOT</strong> put (<strong><em> * </em></strong>) or (<strong><em> / </em></strong>) at the end of the line.</p>
@@ -916,40 +1031,49 @@ _(File list path)_:
   <li><strong><em>/mnt/cache_ssd/Files/MyFolder/*MyFile*</em></strong> , Excludes all folders and files matching the pattern recursively within that folder.</li>
 </ul>
 <p> Size is not tracked for wildcard entries.</p>
+:end
 </blockquote>
 
 _(Ignore file types)_:
 : <select name='filetypesf' size='1' onchange='$(".myfiletypesf").toggleAttr("disabled")'>
-<?=mk_option($cfg['filetypesf'],"no",'No')?>
-<?=mk_option($cfg['filetypesf'],"yes","Yes")?>
+<?=mk_option($cfg['filetypesf'],"no",_('No'))?>
+<?=mk_option($cfg['filetypesf'],"yes",_('Yes'))?>
 </select>
 
 _(Comma separated list of file types)_:
 : <input type='text' name='filetypesv' size='1' class='myfiletypesf' placeholder='jpg, png, zip, txt' value='<?=htmlspecialchars($cfg['filetypesv'])?>' <?=$filetypesfDisabled?>>
 
+:mover_tune_filetypesv_plug:
+
 > A list of file types separated by a <strong>comma</strong>.
+
+:end
 
 _(Ignore All hidden files and directories)_:
 : <select name='ignoreHidden' size='1'>
-<?=mk_option($cfg['ignoreHidden'],"no","No")?>
-<?=mk_option($cfg['ignoreHidden'],"yes","Yes")?>
+<?=mk_option($cfg['ignoreHidden'],"no",_('No'))?>
+<?=mk_option($cfg['ignoreHidden'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_ignorehidden_plug:
 <p>Very few will use this, keep set to No.</p>
 <p>Removes any files or directories that start with a (<strong><em> . </em></strong>).</p>
 <p>Adds (<strong><em> -not -path '*/\.*' </em></strong>) to the end of the find command.</p>
+:end
 </blockquote>
 
 _(Move All from Primary->Secondary (cache:yes) shares when disk is above a certain percentage)_:
 : <select name='omovercfg' size='1' onchange='$(".myomthresh").toggleAttr("disabled")'>
-<?=mk_option($cfg['omovercfg'],"no","No")?>
-<?=mk_option($cfg['omovercfg'],"yes","Yes")?>
+<?=mk_option($cfg['omovercfg'],"no",_('No'))?>
+<?=mk_option($cfg['omovercfg'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_omovercfg_plug:
 <p>Set to <strong>Yes</strong> if you want to move all files from a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share to the array if the percentage below is exceeded.</p>
 <p>This is similar to the original mover and does not apply any filters from this plug-in to the find command sent to the mover binary.</p>
+:end
 </blockquote>
 
 _(Move All from Primary->Secondary shares pool percentage)_:
@@ -961,81 +1085,102 @@ _(Move All from Primary->Secondary shares pool percentage)_:
 <span id="omoverthresh_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 <blockquote class="inline_help">
+:mover_tune_omoverthresh_plug:
 <p>Set to the amount of disk space used on the Primary pool to initiate a move of all files in a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share.</p>
 <p>Filters will still run after, for any remaining pool's that do not meet this threshold.</p>
 <p>This threshold should at a minimum be <strong>5%</strong> larger than <strong><em>Only move at this threshold of used primary (cache) space</em></strong> setting above.</p>
+:end
 </blockquote>
 
 </div>
 
-<div class="title"><span class="center"><i class="fa fa-files-o title"></i>Mover Tuning - Options</span></div>
+<div class="title"><span class="center"><i class="fa fa-files-o title"></i>_(Mover Tuning - Options)_</span></div>
 
 _(Force turbo write during mover)_:
 : <select name='enableTurbo' size='1'>
-<?=mk_option($cfg['enableTurbo'],"no","No")?>
-<?=mk_option($cfg['enableTurbo'],"yes","Yes")?>
+<?=mk_option($cfg['enableTurbo'],"no",_('No'))?>
+<?=mk_option($cfg['enableTurbo'],"yes",_('Yes'))?>
 </select>
+
+:mover_tune_enableturbo_plug:
 
 > Forces unRaid to switch to turbo write mode (reconstruct write) when mover is running.
 
+:end
+
 _(Move files tool)_:
 : <select name='movefilesTool' size='1'>
-<?=mk_option($cfg['movefilesTool'],"rsync",'Rsync')?>
-<?=mk_option($cfg['movefilesTool'],"move","Move")?>
+<?=mk_option($cfg['movefilesTool'],"rsync",_('Rsync'))?>
+<?=mk_option($cfg['movefilesTool'],"move",_('Move'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_movefilestool_plug:
 <p>This will change the tool used for moving files with <strong>plugin filters</strong>, allowing you to select between <strong>Rsync</strong> or <strong>Move</strong> Unraid's built-in file-moving utility.</p>
 <p><strong>Move</strong> - Use Unraid's built-in file-moving tool for moving, but continue to use <strong>Rsync</strong> for syncing files.</p>
 <p><strong>Rsync</strong> - Use Rsync for both moving and syncing files.</p>
+:end
 </blockquote>
 
 _(Move empty folders)_:
 : <select name='moveEmptyFolders' size='1'>
-<?=mk_option($cfg['moveEmptyFolders'],"no",'No')?>
-<?=mk_option($cfg['moveEmptyFolders'],"yes","Yes")?>
+<?=mk_option($cfg['moveEmptyFolders'],"no",_('No'))?>
+<?=mk_option($cfg['moveEmptyFolders'],"yes",_('Yes'))?>
 </select>
+
+:mover_tune_moveemptyfolders_plug:
 
 > This will also move <strong>empty folders</strong> on a share, including those that are not related to the files that were moved.
 
+:end
+
 _(Clean empty folders)_:
 : <select name='cleanFolders' size='1'>
-<?=mk_option($cfg['cleanFolders'],"no",'No')?>
-<?=mk_option($cfg['cleanFolders'],"yes","Yes")?>
-<?=mk_option($cfg['cleanFolders'],"topFolder","Top Folder")?>
+<?=mk_option($cfg['cleanFolders'],"no",_('No'))?>
+<?=mk_option($cfg['cleanFolders'],"yes",_('Yes'))?>
+<?=mk_option($cfg['cleanFolders'],"topFolder",_('Top Folder'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_cleanfolders_plug:
 <p><strong>Yes</strong> - Removes the parent folder <strong>only of moved</strong> files.</p>
 <p><strong>Top Folder</strong> - Removes the top-level <strong>share folder</strong> of the moved content, including <strong>all empty subfolders</strong> on the primary storage.</p>
+:end
 </blockquote>
 
 _(Clean empty ZFS datasets)_:
 : <select name='cleanDatasets' size='1'>
-<?=mk_option($cfg['cleanDatasets'],"no",'No')?>
-<?=mk_option($cfg['cleanDatasets'],"yes","Yes")?>
+<?=mk_option($cfg['cleanDatasets'],"no",_('No'))?>
+<?=mk_option($cfg['cleanDatasets'],"yes",_('Yes'))?>
 </select>
+
+:mover_tune_cleandatasets_plug:
 
 > This will <strong>unmount</strong> and <strong>destroy</strong> the parent ZFS dataset on share of moved files, <strong>only if not contain</strong> child datasets within.
 
+:end
+
 _(Share size calculation)_:
 : <select name='shareCalculation' size='1'>
-<?=mk_option($cfg['shareCalculation'],"no",'No')?>
-<?=mk_option($cfg['shareCalculation'],"yes","Yes")?>
+<?=mk_option($cfg['shareCalculation'],"no",_('No'))?>
+<?=mk_option($cfg['shareCalculation'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_sharecalculation_plug:
 <p>Enable or disable share size calculation on the <strong><em>Primary</em></strong> storage (cache:<strong>only</strong>).</p>
 <p>This runs <strong><code>du</code></strong> on the share, which can be <strong>heavy</strong> on large XFS/Btrfs shares with many files.</p>
+:end
 </blockquote>
 
 _(Synchronize Primary files to Secondary)_:
 : <select name='synchronizeCache' size='1'>
-<?=mk_option($cfg['synchronizeCache'],"no",'No')?>
-<?=mk_option($cfg['synchronizeCache'],"yes","Yes")?>
+<?=mk_option($cfg['synchronizeCache'],"no",_('No'))?>
+<?=mk_option($cfg['synchronizeCache'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_synchronizecache_plug:
 <p>This will synchronize the Primary (cached) files on both Primary and Secondary (array) so they are backed up and parity protected.</p>
 <p>Reading and modification will still occur on Primary. Sync files based on maximum size optionally can be used.</p>
 <p><u>Note:</u></p>
@@ -1043,42 +1188,51 @@ _(Synchronize Primary files to Secondary)_:
   <li><strong>ONLY modified files</strong> since the last sync are <strong>synchronized</strong>.</li>
   <li><strong>ONLY files</strong> on the cache pool <strong>below</strong> moving and freeing thresholds can be <strong>synchronized</strong>.</li>
 </ul>
+:end
 </blockquote>
 
 _(Show advanced options)_:
 : <select name='advancedOptions' size='1' onchange="updateScreenMoverAdvancedOptions(this.value, 'slow')">
-<?=mk_option($cfg['advancedOptions'],"no","No")?>
-<?=mk_option($cfg['advancedOptions'],"yes","Yes")?>
+<?=mk_option($cfg['advancedOptions'],"no",_('No'))?>
+<?=mk_option($cfg['advancedOptions'],"yes",_('Yes'))?>
 </select>
 
+:mover_tune_advancedoptions_plug:
+
 > Show advanced options. Please note that these options are active if set even if not shown.
+
+:end
 
 <div markdown="1" id="moverAdvancedOptions">
 
 _(Rebalance shares)_:
 : <select name='rebalanceShares' size='1'>
-<?=mk_option($cfg['rebalanceShares'],"no",'No')?>
-<?=mk_option($cfg['rebalanceShares'],"run-once","Run once")?>
-<?=mk_option($cfg['rebalanceShares'],"yes","Yes")?>
+<?=mk_option($cfg['rebalanceShares'],"no",_('No'))?>
+<?=mk_option($cfg['rebalanceShares'],"run-once",_('Run once'))?>
+<?=mk_option($cfg['rebalanceShares'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_rebalanceshares_plug:
 <p>Moves files from shares to their Primary and/or Secondary storage if they are spread across <strong><em>Unattended Storage</em></strong> (disks/pools not assigned as a share's Primary or Secondary).</p>
 <p>May move older files from <strong><em>Primary->Secondary</em></strong> or <strong><em>Secondary->Primary</em></strong> if allowed (cache:prefer, cache:yes, cache:only) to free up space.</p>
 <p>Run-once setting will reset back to <strong>No</strong> after next run.</p>
+:end
 </blockquote>
 
 _(Resynchronize all Primary files to Secondary)_:
 : <select name='resynchronizeCache' size='1'>
-<?=mk_option($cfg['resynchronizeCache'],"no",'No')?>
-<?=mk_option($cfg['resynchronizeCache'],"run-once","Run once")?>
-<?=mk_option($cfg['resynchronizeCache'],"yes","Yes")?>
+<?=mk_option($cfg['resynchronizeCache'],"no",_('No'))?>
+<?=mk_option($cfg['resynchronizeCache'],"run-once",_('Run once'))?>
+<?=mk_option($cfg['resynchronizeCache'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_resynchronizecache_plug:
 <p>This will resynchronize the Primary (cached) files on both Primary and Secondary (array) so they are backed up and parity protected.</p>
 <p>All files will be synchronized again independently of modification time.</p>
 <p>This can be a long operation. Run-once setting will reset back to <strong>No</strong> after next run.</p>
+:end
 </blockquote>
 
 </div>
@@ -1090,7 +1244,7 @@ _(Resynchronize all Primary files to Secondary)_:
     <input type="button" id="DONE" value="_(Done)_" onclick="done()">
     <input type="button" id="Defaults" value="_(Defaults)_" onclick="resetDefaults(); location.reload()">
 <?if ($showMoverButton):?>
-    <button type="button" id="StartTuneMoverBtn" class="button" title="Run Mover Tuning..." aria-label="Start Mover Tuning" aria-disabled="<?=$moverRunning ? 'true' : 'false'?>" <?if($moverRunning) echo 'disabled';?>>
+    <button type="button" id="StartTuneMoverBtn" class="button" title="_(Run Mover Tuning...)_" aria-label="_(Start Mover Tuning)_" aria-disabled="<?=$moverRunning ? 'true' : 'false'?>" <?if($moverRunning) echo 'disabled';?>>
     <i id="MoverWrench" class="fa fa-wrench" style="color:<?=$moverRunning ? 'var(--gray-500)' : 'var(--blue-700)'?>;"></i> _(Move now)_
   </button>
     <!-- Spinner outside button -->
@@ -1104,51 +1258,51 @@ _(Resynchronize all Primary files to Secondary)_:
 </form>
 <span id='test'></span>
 
-<div class="title"><span class="left"><i class="fa fa-info-circle title"></i>Mover Tuning - Help</span></div>
-<p>If you need assistance, you can ask in the Unraid community for help.</p>
+<div class="title"><span class="left"><i class="fa fa-info-circle title"></i>_(Mover Tuning - Help)_</span></div>
+<p>_(If you need assistance, you can ask in the Unraid community for help.)_</p>
 
 <div style="font-size:x-small;font-weight:bold;">
-    <i class="fa fa-download"></i> <a href="/plugins/ca.mover.tuning/debug.php">Mover Tuning Debug Package (.zip)</a>
+    <i class="fa fa-download"></i> <a href="/plugins/ca.mover.tuning/debug.php">_(Mover Tuning Debug Package (.zip))_</a>
 </div>
 
 <dl>
-    <dt>Plugin thread @ Unraid community</dt>
-    <dd><span><a href="https://forums.unraid.net/topic/70783-plugin-mover-tuning/" target="_blank" rel="noopener noreferrer">Open</a> - Before proceeding, click on an option or press F1 to read detailed descriptions of all settings.</span></dd>
-    <dt>Maintainers</dt>
+    <dt>_(Plugin thread @ Unraid community)_</dt>
+    <dd><span><a href="https://forums.unraid.net/topic/70783-plugin-mover-tuning/" target="_blank" rel="noopener noreferrer">_(Open)_</a> - _(Before proceeding, click on an option or press F1 to read detailed descriptions of all settings.)_</span></dd>
+    <dt>_(Maintainers)_</dt>
     <dd><span><span class="plugin-year" data-start="2025"></span> - <a href="https://forums.unraid.net/profile/107418-masterwishx/" target="_blank" rel="noopener noreferrer">masterwishx</a> | 
         2024 - <a href="https://github.com/R3yn4ld/ca.mover.tuning" target="_blank" rel="noopener noreferrer">R3yn4ld</a> | 
         2023 - <a href="https://github.com/hugenbd/ca.mover.tuning" target="_blank" rel="noopener noreferrer">hugenbd</a> | 
         2018 - <a href="https://forums.unraid.net/profile/10290-squid/" target="_blank" rel="noopener noreferrer">Andrew Zawadzki</a></span></dd>
 
-    <dt>Want to support the developer and say <strong>Thank You</strong>?</dt>
-    <dd><span>You're welcome! 😊 Thanks for using! <abbr title="All community developers">We</abbr> make those plugins with ❤️ (and a lot of ☕).
-        If you like the work, you can donate via <a href="https://www.paypal.com/donate/?hosted_button_id=UDXM742YK5ZV6" target="_blank" rel="noopener noreferrer"><i class="fa fa-paypal"></i> <strong>PayPal</strong></a>.
+    <dt>_(Want to support the developer and say **Thank You**?)_</dt>
+    <dd><span>_(You're welcome! 😊 Thanks for using!)_ <abbr title="_(All community developers)_">_(We)_</abbr> _(make those plugins with ❤️ (and a lot of ☕).)_
+        _(If you like the work, you can donate via)_ <a href="https://www.paypal.com/donate/?hosted_button_id=UDXM742YK5ZV6" target="_blank" rel="noopener noreferrer"><i class="fa fa-paypal"></i> <strong>PayPal</strong></a>.
     </span></dd>
 
-    <dt>GitHub repository</dt>
-    <dd><a href="https://github.com/masterwishx/ca.mover.tuning" target="_blank" rel="noopener noreferrer"><i class="fa fa-github"></i> Open</a>
+    <dt>_(GitHub repository)_</dt>
+    <dd><a href="https://github.com/masterwishx/ca.mover.tuning" target="_blank" rel="noopener noreferrer"><i class="fa fa-github"></i> _(Open)_</a>
     </dd>
 
-    <dt>Used IDE</dt>
+    <dt>_(Used IDE)_</dt>
     <dd>Visual Studio Code</dd>
 </dl>
 
 <div id="MoverCliHelp" style="display: inline-flex; flex-wrap: wrap; align-items: center; gap: 8px;">
   <span class="mtp-help-toggle" style="cursor: help;">
    <i class="fa fa-info-circle" style="margin-right: 2px;"></i>
-   <strong>CLI help commands</strong>
+   <strong>_(CLI help commands)_</strong>
   </span>
 
   <blockquote class="inline_help" style="max-width: 80%; margin-left: 2px; margin-right: 2px; display: none;">
   <?php if (version_compare($vars['version'] ?? '0.0.0', '7.2.1', '>=')): ?>
     <ul>
-      <li><strong><code>“age_mover --help”</code></strong> — Plugin mover</li>
-      <li><strong><code>“mover --help”</code></strong> — Unraid mover</li>
+      <li><strong><code>“age_mover --help”</code></strong> — _(Plugin mover)_</li>
+      <li><strong><code>“mover --help”</code></strong> — _(Unraid mover)_</li>
     </ul>
     <?php else: ?>
     <ul>
-      <li><strong><code>“mover --help”</code></strong> — Plugin mover</li>
-      <li><strong><code>“mover.old --help”</code></strong> — Unraid mover</li>
+      <li><strong><code>“mover --help”</code></strong> — _(Plugin mover)_</li>
+      <li><strong><code>“mover.old --help”</code></strong> — _(Unraid mover)_</li>
     </ul>
   <?php endif; ?>
   </blockquote>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Mover.tuning.page
@@ -490,7 +490,9 @@ _(Disable Mover running on a schedule)_:
 <?php endif; ?>
 
 <div markdown="1" id="moverTuningSettings">
+
 <?php if (version_compare($vars['version'], '7.2.1', '>=')): ?>
+
 _(Mover Tuning schedule)_:
 : <input type='text' id='tune_cronSchedule' name='moverTuneCron' size='1' class='tune_mycron' placeholder='0 */4 * * *' value='<?=htmlspecialchars($cfg['moverTuneCron'])?>'>
 
@@ -930,7 +932,6 @@ _(Move files that are larger than this size (In MB))_.
   <?=mk_option($cfg['sizeinM'], 9, "9")?>
   <?=mk_option($cfg['sizeinM'], 10, "10")?>
   <?=mk_option($cfg['sizeinM'], 11, "11")?>
-
 	<?for ($ds=12;$ds<1026;$ds+=2):?>
 		<?=mk_option($cfg['sizeinM'], $ds, "$ds")?>
 	<?endfor;?>
@@ -967,7 +968,6 @@ _(Sync files that are smaller than this size (In MB))_.
   <?=mk_option($cfg['sizeinMSync'], 9, "9")?>
   <?=mk_option($cfg['sizeinMSync'], 10, "10")?>
   <?=mk_option($cfg['sizeinMSync'], 11, "11")?>
-
 	<?for ($ds=12;$ds<1026;$ds+=2):?>
 		<?=mk_option($cfg['sizeinMSync'], $ds, "$ds")?>
 	<?endfor;?>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/MoverTuningTranslations.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/MoverTuningTranslations.page
@@ -1,0 +1,13 @@
+Menu="Buttons"
+Link="nav-user"
+---
+<?php
+// Buttons pages run before the tab titles and _( )_ markers are rendered; nothing else in a plugin does.
+// Loads languages/<locale>.txt from this plugin for the two pages that carry Mover Tuning tabs.
+if (in_array($myPage['name'] ?? '', ['Scheduler', 'Share'], true) === true && preg_match('/^[a-z]{2}_[A-Z]{2}$/', $locale ?? '') === 1) {
+  $moverTuningLanguageFile = "$docroot/plugins/ca.mover.tuning/languages/$locale.txt";
+  if (file_exists($moverTuningLanguageFile) === true) {
+    $language = array_merge($language, parse_lang_file($moverTuningLanguageFile));
+  }
+}
+?>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
@@ -151,10 +151,13 @@ $(function() {
 <input type="hidden" name="#file" value="<?=$shareCFG?>">
 
 <? if ($shareName != ""): ?>
+
 <? if (strpos($shareCfgText, 'shareUseCache="no"') !== false || strpos($shareCfgText, 'shareUseCache="only"') !== false): ?>
+
 <div markdown="1" class="shade-<?=$display['theme']?>">
 _(Mover Tuning settings not available for this share)_.
 </div>
+
 <? elseif (strpos($shareCfgText, 'shareUseCache="prefer"') !== false): ?>
 
 <div markdown="1" class="shade-<?=$display['theme']?>">
@@ -268,7 +271,6 @@ _(Only move files larger than this (in MB))_:
   <?= mk_option($cfg['sizeinM'], 9, "9") ?>
   <?= mk_option($cfg['sizeinM'], 10, "10") ?>
   <?= mk_option($cfg['sizeinM'], 11, "11") ?>
-
   <? for ($ds = 12; $ds < 1026; $ds += 2): ?>
   <?= mk_option($cfg['sizeinM'], $ds, "$ds") ?>
   <? endfor; ?>
@@ -512,7 +514,6 @@ _(Only move files larger than this (in MB))_:
   <?= mk_option($cfg['sizeinM'], 9, "9") ?>
   <?= mk_option($cfg['sizeinM'], 10, "10") ?>
   <?= mk_option($cfg['sizeinM'], 11, "11") ?>
-
   <? for ($ds = 12; $ds < 1026; $ds += 2): ?>
   <?= mk_option($cfg['sizeinM'], $ds, "$ds") ?>
   <? endfor; ?>
@@ -549,7 +550,6 @@ _(Sync files that are smaller than this size (In MB))_.
   <?=mk_option($cfg['sizeinMSync'], 9, "9")?>
   <?=mk_option($cfg['sizeinMSync'], 10, "10")?>
   <?=mk_option($cfg['sizeinMSync'], 11, "11")?>
-
 	<?for ($ds=12;$ds<1026;$ds+=2):?>
 		<?=mk_option($cfg['sizeinMSync'], $ds, "$ds")?>
 	<?endfor;?>
@@ -714,12 +714,17 @@ _(Move **ALL** files from current pool (won't use mover settings))_:
 </div>
 
 <? else: ?>
+
 <div markdown="1" class="shade-<?=$display['theme']?>">
 _(Mover Tuning settings not available for this share)_.
 </div>
+
 <? endif; ?>
+
 <? else: ?>
+
 _(Not Applicable (Share Does Not Exist Yet))_!
+
 <? endif; ?>
 
 </form>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/Share.tuning.page
@@ -78,6 +78,12 @@ function mtFillRange(sel, from, to, step) {
   return keep ? '' : $sel.val();
 }
 
+// %1, %2... in a translated template are filled from the extra arguments.
+function mtFmt(tpl) {
+  var args = arguments;
+  return tpl.replace(/%(\d)/g, function(m, i) { return args[i]; });
+}
+
 function mtNotice(id, text) {
   var $n = $(id);
   if (!$n.length) return;
@@ -90,13 +96,13 @@ function mtRebuildThresholds(moving) {
   moving = parseInt(moving, 10) || 0;
 
   var freeing = mtFillRange('select[name="freeingThreshold"]', moving, 0, -5);
-  mtNotice('#freeing_notice', freeing ? 'Freeing threshold lowered to ' + freeing +
-    '% to stay at or below the moving threshold.' : '');
+  mtNotice('#freeing_notice', freeing ?
+    mtFmt('_(Freeing threshold lowered to %1 to stay at or below the moving threshold.)_', freeing + '%') : '');
 
   var $om = $('select[name="omoverthresh"]');
   var omover = mtFillRange($om, moving + 5, 100, 5);
   mtNotice('#omoverthresh_notice', (omover && !$om.prop('disabled')) ?
-    'Move All threshold raised to ' + omover + '% to stay above the moving threshold.' : '');
+    mtFmt('_(Move All threshold raised to %1 to stay above the moving threshold.)_', omover + '%') : '');
 }
 
 // A config saved before the ranges tracked each other can hold a combination this page cannot
@@ -104,20 +110,16 @@ function mtRebuildThresholds(moving) {
 function mtWarnSavedThresholds() {
   var msgs = [];
   if (mtSaved.freeing > mtSaved.moving) {
-    msgs.push('The saved freeing threshold is ' + mtSaved.freeing + '%, above the moving threshold of ' +
-      mtSaved.moving + '%. The mover starts at ' + mtSaved.moving + '% and stops at ' + mtSaved.freeing +
-      '%, so nothing is moved while the pool sits between them. This page now shows ' +
-      $('select[name="freeingThreshold"]').val() + '%, and saving will store that.');
+    msgs.push(mtFmt('_(The saved freeing threshold is %1, above the moving threshold of %2. The mover starts at %2 and stops at %1, so nothing is moved while the pool sits between them. This page now shows %3, and saving will store that.)_',
+      mtSaved.freeing + '%', mtSaved.moving + '%', $('select[name="freeingThreshold"]').val() + '%'));
   }
   if (mtSaved.omoverOn && mtSaved.omover !== null && mtSaved.omover <= mtSaved.moving) {
-    msgs.push('The saved Move All threshold is ' + mtSaved.omover + '%, at or below the moving threshold ' +
-      'of ' + mtSaved.moving + '%. Everything on cache:yes shares moves, skip list and filters ignored, ' +
-      'before the moving threshold is reached. This page now shows ' +
-      $('select[name="omoverthresh"]').val() + '%, and saving will store that.');
+    msgs.push(mtFmt('_(The saved Move All threshold is %1, at or below the moving threshold of %2. Everything on cache:yes shares moves, skip list and filters ignored, before the moving threshold is reached. This page now shows %3, and saving will store that.)_',
+      mtSaved.omover + '%', mtSaved.moving + '%', $('select[name="omoverthresh"]').val() + '%'));
   }
   if (!msgs.length) return;
   if (typeof swal === 'function') {
-    swal({title: 'Mover Tuning thresholds', text: msgs.join('\n\n'), type: 'warning', confirmButtonText: 'OK'});
+    swal({title: '_(Mover Tuning thresholds)_', text: msgs.join('\n\n'), type: 'warning', confirmButtonText: '_(OK)_'});
   } else {
     mtNotice('#freeing_notice', msgs.join(' '));
   }
@@ -151,19 +153,22 @@ $(function() {
 <? if ($shareName != ""): ?>
 <? if (strpos($shareCfgText, 'shareUseCache="no"') !== false || strpos($shareCfgText, 'shareUseCache="only"') !== false): ?>
 <div markdown="1" class="shade-<?=$display['theme']?>">
-_(Mover Tuning settings not available for this share.)_
+_(Mover Tuning settings not available for this share)_.
 </div>
 <? elseif (strpos($shareCfgText, 'shareUseCache="prefer"') !== false): ?>
 
 <div markdown="1" class="shade-<?=$display['theme']?>">
 _(Override Mover Tuning settings for this share)_:
 : <select name="moverOverride" onchange="updateScreenMoverTuning(this.value, 'slow')">
-  <?= mk_option($cfg['moverOverride'], 'no', 'No') ?>
-  <?= mk_option($cfg['moverOverride'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['moverOverride'], 'no', _('No')) ?>
+  <?= mk_option($cfg['moverOverride'], 'yes', _('Yes')) ?>
   </select>
   
-<!--:mover_tuning_override_help:-->
+:mover_tune_moveroverride_plug:
+
 > Select **Yes** to override the primary Mover Tuning settings for this share.
+
+:end
 
 <div markdown="1" id="moverSettings">
 _(Fill up to this level of used Primary (<em>cache</em>) space)_:
@@ -173,20 +178,27 @@ _(Fill up to this level of used Primary (<em>cache</em>) space)_:
 <?endfor;?>
 </select>
 
+:mover_tune_fillupthreshold_plug:
+
 > Set to the amount of disk space used on the <strong><em>Secondary->Primary</em></strong> (cache:<strong>prefer</strong>) drive after the mover has completed its run. Setting this to (<strong><em>95%</em></strong>) means that the mover will continue until <strong><em>95%</em></strong> of the cache pool is filled.
+
+:end
 
 _(Move files to Primary (<em>cache</em>) based on age)_:
 : <select name="age" onchange='$(".myage").toggleAttr("disabled")'>
-  <?= mk_option($cfg['age'], 'no', 'No') ?>
-  <?= mk_option($cfg['age'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['age'], 'no', _('No')) ?>
+  <?= mk_option($cfg['age'], 'yes', _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_age_help:-->
+:mover_tune_share_age_prefer_plug:
+
 > Select **Yes** to move files to the Primary (cache) based on their age (in **days**).
+
+:end
 
 _(Only move files that are older than this (in days))_:
 : <select name="daysold" class='myage' <?= $ageDisabled ?>>
-  <?= mk_option($cfg['daysold'], -1, "Auto")?>
+  <?= mk_option($cfg['daysold'], -1, _('Auto'))?>
   <?= mk_option($cfg['daysold'], 1, "1") ?>
   <?= mk_option($cfg['daysold'], 2, "2") ?>
   <?= mk_option($cfg['daysold'], 3, "3") ?>
@@ -201,35 +213,47 @@ _(Only move files that are older than this (in days))_:
   <? endfor; ?>
   </select>
 
-<!--:mover_tuning_min_age_help:-->
+:mover_tune_share_daysold_plug:
+
 > Select the number of days old a file has to be in order to move (Up To 1 year). Auto will move from the oldest to the most recent, until threshold is met.
+
+:end
 
 _(Use CTIME)_:
 : <select name="ctime" class='myage ctime' <?= $ageDisabled ?> <?= $lockCtime ?> onchange='$(".atime").toggleAttr("disabled")'>
-  <?=mk_option($cfg['ctime'],'no','No')?>
-  <?=mk_option($cfg['ctime'],'yes','Yes')?>
+  <?=mk_option($cfg['ctime'],'no',_('No'))?>
+  <?=mk_option($cfg['ctime'],'yes',_('Yes'))?>
   </select>
 
-<!--:mover_tuning_ctime_help:-->
+:mover_tune_ctime_plug:
+
 > Use <strong>CTIME</strong> <em>( creation time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
+
+:end
 
 _(Use ATIME)_:
 : <select name="atime" class='myage atime' <?= $ageDisabled ?> <?= $lockAtime ?> onchange='$(".ctime").toggleAttr("disabled")'>
-  <?=mk_option($cfg['atime'],'no','No')?>
-  <?=mk_option($cfg['atime'],'yes','Yes')?>
+  <?=mk_option($cfg['atime'],'no',_('No'))?>
+  <?=mk_option($cfg['atime'],'yes',_('Yes'))?>
   </select>
 
-<!--:mover_tuning_atime_help:-->
+:mover_tune_atime_plug:
+
 > Use <strong>ATIME</strong> <em>( access time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
+
+:end
 
 _(Move files based on size)_:
 : <select name="sizef" onchange='$(".mysizef").toggleAttr("disabled")'>
-  <?= mk_option($cfg['sizef'], 'no', 'No') ?>
-  <?= mk_option($cfg['sizef'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['sizef'], 'no', _('No')) ?>
+  <?= mk_option($cfg['sizef'], 'yes', _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_size_help:-->
+:mover_tune_share_sizef_plug:
+
 > Select **Yes** to move files based on their file size.
+
+:end
 
 _(Only move files larger than this (in MB))_:
 : <select name="sizeinM" size="1" class='mysizef' <?= $sizefDisabled ?>>
@@ -250,17 +274,23 @@ _(Only move files larger than this (in MB))_:
   <? endfor; ?>
   </select>
 
-<!--:mover_tuning_min_size_help:-->
+:mover_tune_sizeinm_plug:
+
 > Select the minimum size a file has to be to get moved (in **Megabytes**).
+
+:end
 
 _(Move files based on sparseness)_:
 : <select name="sparsnessf" onchange='$(".mysparsnessf").toggleAttr("disabled")'>
-  <?= mk_option($cfg['sparsnessf'], 'no', 'No') ?>
-  <?= mk_option($cfg['sparsnessf'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['sparsnessf'], 'no', _('No')) ?>
+  <?= mk_option($cfg['sparsnessf'], 'yes', _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_sparseness_help:-->
+:mover_tune_share_sparsnessf_plug:
+
 > Select **Yes** to move files based on their sparseness.
+
+:end
 
 _(Move files that are greater than this sparseness)_:
 : <select name='sparsnessv' class='mysparsnessf' <?= $sparsnessfDisabled ?>>
@@ -275,47 +305,65 @@ _(Move files that are greater than this sparseness)_:
 	<?= mk_option($cfg['sparsnessv'], 9, "0.9") ?>
   </select>
 
-<!--:mover_tuning_min_sparseness_help:-->
+:mover_tune_share_sparsnessv_plug:
+
 > Select the minimum sparseness a file has to be to get moved.
+
+:end
 
 _(Skip files listed in text file)_:
 : <select name='filelistf' onchange='$(".myfilelistf").toggleAttr("disabled")'>
-  <?= mk_option($cfg['filelistf'], "no", 'No') ?>
-  <?= mk_option($cfg['filelistf'], "yes", "Yes") ?>
+  <?= mk_option($cfg['filelistf'], "no", _('No')) ?>
+  <?= mk_option($cfg['filelistf'], "yes", _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_file_list_help:-->
+:mover_tune_filelistf_plug:
+
 > Select **Yes** to skip files which have been listed in a specified text file.
+
+:end
 
 _(File list path)_:
 : <input type='text' name='filelistv' class='myfilelistf' value='<?=htmlspecialchars($cfg['filelistv'], ENT_QUOTES | ENT_SUBSTITUTE)?>' <?= $filelistfDisabled ?>>
 
-<!--:mover_tuning_file_list_path_help:-->
+:mover_tune_share_filelistv_plug:
+
 > Specify the full path to a text file that contains the list of files the mover should skip.
+
+:end
 
 _(Skip file types)_:
 : <select name='filetypesf' onchange='$(".myfiletypesf").toggleAttr("disabled")'>
-  <?= mk_option($cfg['filetypesf'], "no", 'No') ?>
-  <?= mk_option($cfg['filetypesf'], "yes", "Yes") ?>
+  <?= mk_option($cfg['filetypesf'], "no", _('No')) ?>
+  <?= mk_option($cfg['filetypesf'], "yes", _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_file_type_help:-->
+:mover_tune_filetypesf_plug:
+
 > Select **Yes** to skip specific file types in addition to those selected globally.
+
+:end
 
 _(Comma separated list of file types)_:
 : <input type='text' name='filetypesv' class='myfiletypesf' value='<?=htmlspecialchars($cfg['filetypesv'], ENT_QUOTES | ENT_SUBSTITUTE)?>' <?= $filetypesfDisabled ?>>
 
-<!--:mover_tuning_file_type_delimited_help:-->
+:mover_tune_share_filetypesv_plug:
+
 > Specify the file types to be skipped, separated by a comma (e.g. **".txt,.mp3,.pdf"**).
+
+:end
 
 _(Ignore All hidden files and directories)_:
 : <select name='ignoreHidden'>
-  <?= mk_option($cfg['ignoreHidden'], "no", "No") ?>
-  <?= mk_option($cfg['ignoreHidden'], "yes", "Yes") ?>
+  <?= mk_option($cfg['ignoreHidden'], "no", _('No')) ?>
+  <?= mk_option($cfg['ignoreHidden'], "yes", _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_hidden_files_help:-->
+:mover_tune_share_ignorehidden_plug:
+
 > Select **Yes** to skip all hidden files and directories (starting with **"."**).
+
+:end
 
 </div>
 </div>
@@ -330,7 +378,11 @@ _(Ignore All hidden files and directories)_:
 _(Move **ALL** files to current pool (won't use mover settings))_:
 : <span><input type="button" id="MoveShare" value="_(Move Now)_" onclick="moveShareNow()"></span>
 
+:mover_tune_share_moveshare_prefer_plug:
+
 > Clicking the **Move Now** button will invoke the **unraid mover** specifically for this share. It will move the entire share **_Secondary->Primary_** storage space, disregarding any existing mover settings.
+
+:end
 </div>
 
 <? elseif (strpos($shareCfgText, 'shareUseCache="yes"') !== false): ?>
@@ -338,12 +390,15 @@ _(Move **ALL** files to current pool (won't use mover settings))_:
 <div markdown="1" class="shade-<?=$display['theme']?>">
 _(Override Mover Tuning settings for this share)_:
 : <select name="moverOverride" onchange="updateScreenMoverTuning(this.value, 'slow')">
-  <?= mk_option($cfg['moverOverride'], 'no', 'No') ?>
-  <?= mk_option($cfg['moverOverride'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['moverOverride'], 'no', _('No')) ?>
+  <?= mk_option($cfg['moverOverride'], 'yes', _('Yes')) ?>
   </select>
   
-<!--:mover_tuning_override_help:-->
+:mover_tune_moveroverride_plug:
+
 > Select **Yes** to override the primary Mover Tuning settings for this share.
+
+:end
 
 <div markdown="1" id="moverSettings">
 _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
@@ -353,7 +408,11 @@ _(Only move if above this threshold of used Primary (<em>cache</em>) space)_:
 <?endfor;?>
 </select>
 
+:mover_tune_share_movingthreshold_plug:
+
 > Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive for mover to run. When this threshold is reached, the mover will start running to move data off the cache pool.
+
+:end
 
 _(Free down to this level of used Primary (<em>cache</em>) space)_:
 : <select name="freeingThreshold" size="1" onchange='mtNotice("#freeing_notice","")'>
@@ -363,20 +422,27 @@ _(Free down to this level of used Primary (<em>cache</em>) space)_:
 </select>
 <span id="freeing_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
+:mover_tune_share_freeingthreshold_plug:
+
 > Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive after the mover has completed its run. Setting this to (<strong><em> 0% </em></strong>) means that the mover will continue until all data is moved off the cache pool.
+
+:end
 
 _(Move files off Primary (<em>cache</em>) based on age)_:
 : <select name="age" onchange='$(".myage").toggleAttr("disabled")'>
-  <?= mk_option($cfg['age'], 'no', 'No') ?>
-  <?= mk_option($cfg['age'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['age'], 'no', _('No')) ?>
+  <?= mk_option($cfg['age'], 'yes', _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_age_help:-->
+:mover_tune_share_age_yes_plug:
+
 > Select **Yes** to move files off of the Primary (cache) based on their age (in **days**).
+
+:end
 
 _(Only move files that are older than this (in days))_:
 : <select name="daysold" class='myage' <?= $ageDisabled ?>>
-  <?= mk_option($cfg['daysold'], -1, "Auto")?>
+  <?= mk_option($cfg['daysold'], -1, _('Auto'))?>
   <?= mk_option($cfg['daysold'], 1, "1") ?>
   <?= mk_option($cfg['daysold'], 2, "2") ?>
   <?= mk_option($cfg['daysold'], 3, "3") ?>
@@ -391,35 +457,47 @@ _(Only move files that are older than this (in days))_:
   <? endfor; ?>
   </select>
 
-<!--:mover_tuning_min_age_help:-->
+:mover_tune_share_daysold_plug:
+
 > Select the number of days old a file has to be in order to move (Up To 1 year). Auto will move from the oldest to the most recent, until threshold is met.
+
+:end
 
 _(Use CTIME)_:
 : <select name="ctime" class='myage ctime' <?= $ageDisabled ?> <?= $lockCtime ?> onchange='$(".atime").toggleAttr("disabled")'>
-  <?=mk_option($cfg['ctime'],'no','No')?>
-  <?=mk_option($cfg['ctime'],'yes','Yes')?>
+  <?=mk_option($cfg['ctime'],'no',_('No'))?>
+  <?=mk_option($cfg['ctime'],'yes',_('Yes'))?>
   </select>
 
-<!--:mover_tuning_ctime_help:-->
+:mover_tune_ctime_plug:
+
 > Use <strong>CTIME</strong> <em>( creation time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
+
+:end
 
 _(Use ATIME)_:
 : <select name="atime" class='myage atime' <?= $ageDisabled ?> <?= $lockAtime ?> onchange='$(".ctime").toggleAttr("disabled")'>
-  <?=mk_option($cfg['atime'],'no','No')?>
-  <?=mk_option($cfg['atime'],'yes','Yes')?>
+  <?=mk_option($cfg['atime'],'no',_('No'))?>
+  <?=mk_option($cfg['atime'],'yes',_('Yes'))?>
   </select>
 
-<!--:mover_tuning_atime_help:-->
+:mover_tune_atime_plug:
+
 > Use <strong>ATIME</strong> <em>( access time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
+
+:end
 
 _(Move files based on size)_:
 : <select name="sizef" onchange='$(".mysizef").toggleAttr("disabled")'>
-  <?= mk_option($cfg['sizef'], 'no', 'No') ?>
-  <?= mk_option($cfg['sizef'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['sizef'], 'no', _('No')) ?>
+  <?= mk_option($cfg['sizef'], 'yes', _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_size_help:-->
+:mover_tune_share_sizef_plug:
+
 > Select **Yes** to move files based on their file size.
+
+:end
 
 _(Only move files larger than this (in MB))_:
 : <select name="sizeinM" size="1" class='mysizef' <?= $sizefDisabled ?>>
@@ -440,16 +518,23 @@ _(Only move files larger than this (in MB))_:
   <? endfor; ?>
   </select>
 
-<!--:mover_tuning_min_size_help:-->
+:mover_tune_sizeinm_plug:
+
 > Select the minimum size a file has to be to get moved (in **Megabytes**).
+
+:end
 
 _(Sync files based on maximum size)_?
 : <select name="sizefSync" size='1' onchange='$(".mysizefSync").toggleAttr("disabled")'>
-       <?=mk_option($cfg['sizefSync'],'no','No')?>
-       <?=mk_option($cfg['sizefSync'],'yes','Yes')?>
+       <?=mk_option($cfg['sizefSync'],'no',_('No'))?>
+       <?=mk_option($cfg['sizefSync'],'yes',_('Yes'))?>
 </select>
 
+:mover_tune_sizefsync_plug:
+
 > Select <strong>yes</strong> if you want to sync files based on their size in <strong>MB</strong>. This option is only applicable when the Synchronize or Resynchronize feature is enabled.
+
+:end
 
 _(Sync files that are smaller than this size (In MB))_.
 : <select name="sizeinMSync" size="1" class='mysizefSync' <?=$sizefSyncDisabled?>>
@@ -470,16 +555,23 @@ _(Sync files that are smaller than this size (In MB))_.
 	<?endfor;?>
 </select>
 
+:mover_tune_sizeinmsync_plug:
+
 > Select the maximum size a file has to be to get synched (in **Megabytes**).
+
+:end
 
 _(Move files based on sparseness)_:
 : <select name="sparsnessf" onchange='$(".mysparsnessf").toggleAttr("disabled")'>
-  <?= mk_option($cfg['sparsnessf'], 'no', 'No') ?>
-  <?= mk_option($cfg['sparsnessf'], 'yes', 'Yes') ?>
+  <?= mk_option($cfg['sparsnessf'], 'no', _('No')) ?>
+  <?= mk_option($cfg['sparsnessf'], 'yes', _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_sparseness_help:-->
+:mover_tune_share_sparsnessf_plug:
+
 > Select **Yes** to move files based on their sparseness.
+
+:end
 
 _(Move files that are greater than this sparseness)_:
 : <select name='sparsnessv' class='mysparsnessf' <?= $sparsnessfDisabled ?>>
@@ -494,57 +586,77 @@ _(Move files that are greater than this sparseness)_:
 	<?= mk_option($cfg['sparsnessv'], 9, "0.9") ?>
   </select>
 
-<!--:mover_tuning_min_sparseness_help:-->
+:mover_tune_share_sparsnessv_plug:
+
 > Select the minimum sparseness a file has to be to get moved.
+
+:end
 
 _(Skip files listed in text file)_:
 : <select name='filelistf' onchange='$(".myfilelistf").toggleAttr("disabled")'>
-  <?= mk_option($cfg['filelistf'], "no", 'No') ?>
-  <?= mk_option($cfg['filelistf'], "yes", "Yes") ?>
+  <?= mk_option($cfg['filelistf'], "no", _('No')) ?>
+  <?= mk_option($cfg['filelistf'], "yes", _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_file_list_help:-->
+:mover_tune_filelistf_plug:
+
 > Select **Yes** to skip files which have been listed in a specified text file.
+
+:end
 
 _(File list path)_:
 : <input type='text' name='filelistv' class='myfilelistf' value='<?=htmlspecialchars($cfg['filelistv'], ENT_QUOTES | ENT_SUBSTITUTE)?>' <?=$filelistfDisabled?>>
 
-<!--:mover_tuning_file_list_path_help:-->
+:mover_tune_share_filelistv_plug:
+
 > Specify the full path to a text file that contains the list of files the mover should skip.
+
+:end
 
 _(Skip file types)_:
 : <select name='filetypesf' onchange='$(".myfiletypesf").toggleAttr("disabled")'>
-  <?= mk_option($cfg['filetypesf'], "no", 'No') ?>
-  <?= mk_option($cfg['filetypesf'], "yes", "Yes") ?>
+  <?= mk_option($cfg['filetypesf'], "no", _('No')) ?>
+  <?= mk_option($cfg['filetypesf'], "yes", _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_file_type_help:-->
+:mover_tune_filetypesf_plug:
+
 > Select **Yes** to skip specific file types in addition to those selected globally.
+
+:end
 
 _(Comma separated list of file types)_:
 : <input type='text' name='filetypesv' class='myfiletypesf' value='<?=htmlspecialchars($cfg['filetypesv'], ENT_QUOTES | ENT_SUBSTITUTE)?>' <?=$filetypesfDisabled?>>
 
-<!--:mover_tuning_file_type_delimited_help:-->
+:mover_tune_share_filetypesv_plug:
+
 > Specify the file types to be skipped, separated by a comma (e.g. **".txt,.mp3,.pdf"**).
+
+:end
 
 _(Ignore All hidden files and directories)_:
 : <select name='ignoreHidden'>
-  <?= mk_option($cfg['ignoreHidden'], "no", "No") ?>
-  <?= mk_option($cfg['ignoreHidden'], "yes", "Yes") ?>
+  <?= mk_option($cfg['ignoreHidden'], "no", _('No')) ?>
+  <?= mk_option($cfg['ignoreHidden'], "yes", _('Yes')) ?>
   </select>
 
-<!--:mover_tuning_hidden_files_help:-->
+:mover_tune_share_ignorehidden_plug:
+
 > Select **Yes** to skip all hidden files and directories (starting with **"."**).
+
+:end
 
 _(Move All from Primary->Secondary (cache:yes) shares when disk is above a certain percentage)_:
 : <select name='omovercfg' size='1' onchange='$(".myomthresh").toggleAttr("disabled")'>
-<?=mk_option($cfg['omovercfg'],"no","No")?>
-<?=mk_option($cfg['omovercfg'],"yes","Yes")?>
+<?=mk_option($cfg['omovercfg'],"no",_('No'))?>
+<?=mk_option($cfg['omovercfg'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_omovercfg_plug:
 <p>Set to <strong>Yes</strong> if you want to move all files from a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share to the array if the percentage below is exceeded.</p>
 <p>This is similar to the original mover and does not apply any filters from this plug-in to the find command sent to the mover binary.</p>
+:end
 </blockquote>
 
 _(Move All from Primary->Secondary (cache:yes) shares pool percentage)_:
@@ -556,18 +668,21 @@ _(Move All from Primary->Secondary (cache:yes) shares pool percentage)_:
 <span id="omoverthresh_notice" class="orange-text" style="display:none; font-style:italic;"></span>
 
 <blockquote class="inline_help">
+:mover_tune_omoverthresh_plug:
 <p>Set to the amount of disk space used on the Primary pool to initiate a move of all files in a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share.</p>
 <p>Filters will still run after, for any remaining pool's that do not meet this threshold.</p>
 <p>This threshold should at a minimum be <strong>5%</strong> larger than <strong><em>Only move at this threshold of used primary (cache) space</em></strong> setting above.</p>
+:end
 </blockquote>
 
 _(Synchronize Primary files to Secondary)_:
 : <select name='synchronizeCache' size='1'>
-<?=mk_option($cfg['synchronizeCache'],"no",'No')?>
-<?=mk_option($cfg['synchronizeCache'],"yes","Yes")?>
+<?=mk_option($cfg['synchronizeCache'],"no",_('No'))?>
+<?=mk_option($cfg['synchronizeCache'],"yes",_('Yes'))?>
 </select>
 
 <blockquote class="inline_help">
+:mover_tune_synchronizecache_plug:
 <p>This will synchronize the Primary (cached) files on both Primary and Secondary (array) so they are backed up and parity protected.</p>
 <p>Reading and modification will still occur on Primary. Sync files based on maximum size optionally can be used.</p>
 <p><u>Note:</u></p>
@@ -575,6 +690,7 @@ _(Synchronize Primary files to Secondary)_:
   <li><strong>ONLY modified files</strong> since the last sync are <strong>synchronized</strong>.</li>
   <li><strong>ONLY files</strong> on the cache pool <strong>below</strong> moving and freeing thresholds can be <strong>synchronized</strong>.</li>
 </ul>
+:end
 </blockquote>
 
 </div>
@@ -590,7 +706,11 @@ _(Synchronize Primary files to Secondary)_:
 _(Move **ALL** files from current pool (won't use mover settings))_:
 : <span><input type="button" id="MoveShare" value="_(Move Now)_" onclick="moveShareNow()"></span>
 
+:mover_tune_share_moveshare_yes_plug:
+
 > Clicking the **Move Now** button will invoke the **unraid mover** specifically for this share. It will move the entire share **_Primary->Secondary_** storage space, disregarding any existing mover settings.
+
+:end
 </div>
 
 <? else: ?>

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/languages/en_US.txt
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/languages/en_US.txt
@@ -1,0 +1,492 @@
+; Mover Tuning plugin (ca.mover.tuning) - English master file for translations
+;
+; To add a language, copy this file to <locale>.txt in this folder, using the folder name of the
+; installed Unraid language pack (for example zh_CN.txt), and fill in the text after each equal sign.
+; The file is read on the Settings > Scheduler and share pages and by the mover notifications.
+;
+; PART 1: single line entries. Keep the English text left of the equal sign as it is; an empty
+; translation keeps the English text. Words every Unraid language pack already translates
+; (Yes, No, Apply, Done, ...) are not repeated here.
+
+All community developers=
+Allow force mover schedule to run during a parity checkrebuild=Allow force mover schedule to run during a parity check/rebuild
+Array → Cache=
+Before proceeding, click on an option or press F1 to read detailed descriptions of all settings=Before proceeding, click on an option or press F1 to read detailed descriptions of all settings.
+by=
+Cache disk not enabled=Cache disk not enabled!
+Cache → Array=
+Clean empty folders=
+Clean empty ZFS datasets=
+CLI help commands=
+Comma separated list of file types=
+Cron Schedule to force move all of files=
+Debug Log Mover Tuning plugin actions=
+Defaults=
+Delete Mover helper files over than this days old=
+Delete Mover Log files over than this days old=
+Disable Mover running on a schedule=
+disables test mode=
+disables the plugins schedule=disables the plugin's schedule
+disables validation of input filenames=
+enable smart caching=
+Error checking mover status Please refresh the page=Error checking mover status. Please refresh the page.
+Errors Only=
+Failed to start Mover Tuning Check the logs=Failed to start Mover Tuning. Check the logs.
+File and Syslog=File (and Syslog)
+File list path=
+File Only=
+Fill upprime up to this level of used Primary cache space=Fill up/prime up to this level of used Primary (<em>cache</em>) space
+Fill up to this level of used Primary cache space=Fill up to this level of used Primary (<em>cache</em>) space
+Force move of all files on a schedule=
+Force turbo write during mover=
+Free downprime up to this level of used Primary cache space=Free down/prime up to this level of used Primary (<em>cache</em>) space
+Free down to this level of used Primary cache space=Free down to this level of used Primary (<em>cache</em>) space
+Freeing threshold lowered to %1 to stay at or below the moving threshold=Freeing threshold lowered to %1 to stay at or below the moving threshold.
+GitHub repository=
+Happy New Year=Happy New Year!
+Idle=
+If you like the work, you can donate via=
+If you need assistance, you can ask in the Unraid community for help=If you need assistance, you can ask in the Unraid community for help.
+If you want Mover Tuning to fully manage scheduling, disable it in Mover Settings=If you want Mover Tuning to fully manage scheduling, disable it in Mover Settings.
+Ignore All hidden files and directories=
+Ignore files and folders listed inside of a text file=
+Ignore file types=
+Invalid characters to block=
+Let scheduled mover run during a parity check rebuild=Let scheduled mover run during a parity check / rebuild
+Log Mover Tuning plugin actions=
+Logs parent folder for Mover Tuning plugin=
+Low=
+Maintainers=
+make those plugins with ❤️ and a lot of ☕=make those plugins with ❤️ (and a lot of ☕).
+Move ALL files from current pool wont use mover settings=Move **ALL** files from current pool (won't use mover settings)
+Move ALL files to current pool wont use mover settings=Move **ALL** files to current pool (won't use mover settings)
+Move All from Primary->Secondary cacheyes shares pool percentage=Move All from Primary->Secondary (cache:yes) shares pool percentage
+Move All from Primary->Secondary cacheyes shares when disk is above a certain percentage=Move All from Primary->Secondary (cache:yes) shares when disk is above a certain percentage
+Move All from Primary->Secondary shares pool percentage=
+Move All threshold raised to %1 to stay above the moving threshold=Move All threshold raised to %1 to stay above the moving threshold.
+Moved Only=
+Move empty folders=
+Move files based on minimum size=
+Move files based on size=
+Move files based on sparseness=
+Move files off Primary cache based on age=Move files off Primary (<em>cache</em>) based on age
+Move files off Primary cache based on sparseness=Move files off Primary (cache) based on sparseness
+Move files that are greater than this many days old=
+Move files that are greater than this sparseness=
+Move files that are greather than this sparseness=
+Move files that are larger than this size In MB=Move files that are larger than this size (In MB)
+Move files tool=
+Move files to Primary cache based on age=Move files to Primary (<em>cache</em>) based on age
+Move now=
+Move Now=
+Move Now button follows plug-in filters=
+Mover is running=Mover is running...
+Mover Tuning=
+Mover Tuning - Filters=
+Mover Tuning - Help=
+Mover Tuning - Options=
+Mover Tuning - Plugin Settings=
+Mover Tuning - Share Settings=
+Mover Tuning Debug Package zip=Mover Tuning Debug Package (.zip)
+Mover Tuning schedule=
+Mover Tuning settings not available for this share=
+Mover Tuning thresholds=
+Not Applicable Share Does Not Exist Yet=Not Applicable (Share Does Not Exist Yet)
+Notify Mover Tuning plugin actions=
+Only move files larger than this in MB=Only move files larger than this (in MB)
+Only move files that are older than this in days=Only move files that are older than this (in days)
+Only move if above this threshold of used Primary cache space=Only move if above this threshold of used Primary (<em>cache</em>) space
+Open=
+Override Mover Tuning settings for this share=
+Plugin mover=
+Plugin thread @ Unraid community=
+Priority for disk IO=Priority for disk I/O
+Priority for mover process=
+Rebalance shares=
+Resynchronize all Primary files to Secondary=
+Rsync=
+Run Mover Tuning=Run Mover Tuning...
+Run once=
+Script to run after mover No checks, always runs=Script to run after mover (No checks, always runs)
+Script to run before mover No checks, always runs=Script to run before mover (No checks, always runs)
+Share size calculation=
+Show advanced filters=
+Show advanced options=
+Show advanced settings=
+Skip files listed in text file=
+Skip file types=
+Starting with Unraid 721, Mover Tuning plugin behavior has changed=Starting with Unraid 7.2.1, Mover Tuning plugin behavior has changed
+Start Mover Tuning=
+Sync files based on maximum size=
+Sync files that are smaller than this size In MB=Sync files that are smaller than this size (In MB)
+Synchronize Primary files to Secondary=
+Test Mode - no files will be movedsynced=Test Mode - no files will be moved/synced.
+Test Mode dry run=Test Mode (dry run)
+Thank you for using this plugin=Thank you for using this plugin.
+The saved freeing threshold is %1, above the moving threshold of %2 The mover starts at %2 and stops at %1, so nothing is moved while the pool sits between them This page now shows %3, and saving will store that=The saved freeing threshold is %1, above the moving threshold of %2. The mover starts at %2 and stops at %1, so nothing is moved while the pool sits between them. This page now shows %3, and saving will store that.
+The saved Move All threshold is %1, at or below the moving threshold of %2 Everything on cacheyes shares moves, skip list and filters ignored, before the moving threshold is reached This page now shows %3, and saving will store that=The saved Move All threshold is %1, at or below the moving threshold of %2. Everything on cache:yes shares moves, skip list and filters ignored, before the moving threshold is reached. This page now shows %3, and saving will store that.
+Top Folder=
+Unraid mover=
+Unraid Mover schedule is currently enabled=Unraid Mover schedule is currently **enabled**
+Use ATIME=
+Use CTIME=
+Used IDE=
+User shares not enabled=User shares not enabled!
+Validate input filenames to prevent attacks=
+Very Low=
+Want to support the developer and say Thank You=Want to support the developer and say **Thank You**?
+We=
+Wishing you a stable array, fast mover runs, and zero parity errors=Wishing you a stable array, fast mover runs, and zero parity errors!
+Youre welcome 😊 Thanks for using=You're welcome! 😊 Thanks for using!
+• In the CLI, use “age_mover --help” for plugin commands Running “mover --help” will call the built-in Unraid mover=• In the CLI, use **“age_mover --help”** for plugin commands. Running **“mover --help”** will call the built-in Unraid mover.
+• The built-in Unraid mover can still be triggered using “Force move all files on a schedule” Cron schedule in Plugin Settings=• The built-in Unraid mover can still be triggered using **“Force move all files on a schedule”** (Cron schedule) in Plugin Settings.
+• The plugin is now separated from the built-in Unraid mover=• The plugin is now separated from the built-in Unraid mover.
+• To disable the built-in Unraid mover schedule, set “Mover schedule” in Mover Settings to Disabled=• To disable the built-in Unraid mover schedule, set **“Mover schedule”** in Mover Settings to **Disabled**.
+• Use the “Mover Tuning Schedule” in the plugin settings to schedule Mover Tuning instead=• Use the **“Mover Tuning Schedule”** in the plugin settings to schedule **Mover Tuning** instead.
+• “Move Now” in Mover Tuning → Options runs the plugin age_mover Mover Tuning=• **“Move Now”** in Mover Tuning → Options runs the plugin age_mover (Mover Tuning).
+• “Move Now” in the main Mover Settings runs the built-in Unraid mover=• **“Move Now”** in the main Mover Settings runs the built-in Unraid mover.
+• “Move” on the Main page also runs the built-in Unraid mover=• **“Move”** on the Main page also runs the built-in Unraid mover.
+
+; PART 2: multi line sections. Translate only the text between the opening tag and :end.
+; Keep the HTML tags. A line containing an equal sign must start with the > character.
+
+:mover_tune_disable_plug:
+<p>This will <strong>prevent</strong> mover from running at the schedule set in <strong>Mover Tuning Settings</strong>.</p>
+<p>You will only be able to run mover by <strong>manually</strong> invoking it:</p>
+<ul>
+  <li>Press the <strong>“Move now”</strong> button in <strong>Mover Tuning - Options</strong>.</li>
+  <li>Run <strong>“age_mover start”</strong> from the <strong>CLI</strong>.</li>
+</ul>
+:end
+
+:mover_tune_disable_legacy_plug:
+<p>This will <strong>prevent</strong> mover from running at the schedule set in <strong>Mover Settings</strong>.</p>
+<p>You will only be able to run mover by <strong>manually</strong> invoking it:</p>
+<ul>
+  <li>Press the <strong>“Move now”</strong> button in <strong>Mover Settings</strong>.</li>
+  <li>Press <strong>“Move”</strong> on the <strong>Main</strong> page.</li>
+  <li>Run <strong>“mover start”</strong> from the <strong>CLI</strong>.</li>
+</ul>
+:end
+
+:mover_tune_movertunecron_plug:
+> Runs the <strong><code>age_mover</code></strong> schedule from the Mover Tuning plugin using your custom cron entry (includes all plugin filters).
+>
+> Cron Schedule entry example <strong>0 */4 * * *</strong>.&nbsp; To run at <em>every</em><strong> 4 hours</strong>.&nbsp; <a href="https://crontab.guru/" target="_blank" rel="noopener noreferrer"><i class="fa fa-clock-o"></i> What Is Cron</a>
+:end
+
+:mover_tune_testmode_plug:
+<p> Test Mode will <strong>Not</strong> run mover but will output the custom find command results to <em>/tmp/ca.mover.tuning/</em>.</p>
+<p> Caution - If you have "Move Now button follows plug-in filters" set to <strong>No</strong>, original Mover will still run.</p>
+:end
+
+:mover_tune_validate_plug:
+<p> <strong><em>In cybersecurity, filenames can be a critical vector for potential attacks and system vulnerabilities. Unsanitized filenames pose significant risks that can compromise system integrity and security.</em></strong></p>
+<p> Validate input filenames will check every filename before it is processed by the Mover. This ensures that <strong>only valid</strong> filenames are accepted, <strong>reducing the risk</strong> of attacks and vulnerabilities.</p>
+<p> Disable <strong>Only</strong> if you have many files to move and you are <strong>sure</strong> that all filenames are <strong>valid</strong> and do not contain any potential security risks.</p>
+<p> 1. <strong>Check filename length</strong> - If the filename exceeds 255 characters, it will be rejected.</p>
+<p> 2. <strong>Check for invalid characters</strong> - The filename should not contain any characters that are considered invalid for filenames, such as 
+(<strong><em> $ </em></strong>), (<strong><em> / </em></strong>), (<strong><em> < </em></strong>), (<strong><em> > </em></strong>), (<strong><em> : </em></strong>), (<strong><em> " </em></strong>), (<strong><em> | </em></strong>), (<strong><em> ? </em></strong>), (<strong><em> * </em></strong>).</p>
+<p> 3. <strong>Prevent path traversal</strong> - The filename should not contain any characters that can be used to traverse directories, such as (<strong><em> ../ </em></strong>).</p>
+<p> If one of these checks fails, the filename will be rejected.</p>
+:end
+
+:mover_tune_invalidfilechars_plug:
+<p> The filename characters such as:
+  <strong><em>$</em></strong>
+  <strong><em>/</em></strong>
+  <strong><em><</em></strong>
+  <strong><em>></em></strong>
+  <strong><em>:</em></strong>
+  <strong><em>"</em></strong>
+  <strong><em>|</em></strong>
+  <strong><em>?</em></strong>
+  <strong><em>*</em></strong>.
+</p>
+:end
+
+:mover_tune_logging_plug:
+<p> Enables or disables logging from this plugin.</p>
+<p><strong>File (and Syslog)</strong> will store to <strong>SYSLOG</strong> and to the log file.</p>
+<p><strong>File Only</strong> will store <strong>only</strong> to the log file.</p>
+<p> Logs are displayed in <strong>SYSLOG</strong> and stored at <strong><em>/tmp/ca.mover.tuning/Mover_tuning_xxx.log</em></strong> by default.</p>
+:end
+
+:mover_tune_debuglogging_plug:
+<p> Enables or disables debug logging from this plugin.</p>
+<p><strong>File (and Syslog)</strong> will store to <strong>SYSLOG</strong> and to the log file.</p>
+<p><strong>File Only</strong> will store <strong>only</strong> to the log file.</p>
+<p> Debug Logs are displayed in <strong>SYSLOG</strong> and stored at <strong><em>/tmp/ca.mover.tuning/Debug_Mover_tuning_xxx.log</em></strong> by default.</p>
+:end
+
+:mover_tune_notify_plug:
+<p>Enables or disables notifications from this plugin. Notifications are displayed in Unriad GUI.</p>
+<p><strong>Errors Only</strong> will send a notification <strong>only</strong> when an error occurs.</p>
+<p><strong>Moved Only</strong> will send a notification <strong>only</strong> when files are moved or when an error occurs, not every time the mover is running.</p>
+:end
+
+:mover_tune_loggingfolder_plug:
+> Path to a parent Logs folder <strong><em>/tmp</em></strong>. Logs are stored at this parent path, by default at <strong><em>/tmp/ca.mover.tuning</em></strong>.
+:end
+
+:mover_tune_logfilesdaysold_plug:
+> Select the number of **days old** for Mover Tuning plugin to delete log files **_*.log_** and text files **_*.txt_**.
+:end
+
+:mover_tune_listfilesdaysold_plug:
+> Select the number of **days old** for Mover Tuning plugin to delete list files **<em>*.list</em>**.
+:end
+
+:mover_tune_advancedsettings_plug:
+> Show advanced settings options. Please note that these settings are active if set even if not shown.
+:end
+
+:mover_tune_parity_plug:
+> If a parity check or disk rebuild is in progress, this will prevent mover from running.
+:end
+
+:mover_tune_moverio_plug:
+<p>The above two options set the priority for the mover process.</p>
+<p>Setting these options may help with circumstances where when mover runs other applications may pause or buffer.</p>
+<p>Note that moving the files may take <strong>longer</strong> when setting these options.</p>
+:end
+
+:mover_tune_force_plug:
+> Select <strong>Yes</strong> to run <strong>original mover</strong> on a custom cron schedule (ignores plugin filters).
+:end
+
+:mover_tune_cron_plug:
+> Cron Schedule entry example <strong>20 4 1 * *</strong>.&nbsp; To run the <em>first day of the month at </em><strong>4:20 AM</strong>.&nbsp; <a href="https://crontab.guru/" target="_blank" rel="noopener noreferrer"><i class="fa fa-clock-o"></i> What Is Cron</a> 
+:end
+
+:mover_tune_forceparity_plug:
+<p>Setting a cron schedule to force a move will run mover on that schedule.</p>
+<p>Example: In Mover Settings you would have a schedule of Hourly. During that schedule the rules above are followed.</p>
+<p>The cron schedule for a force move could be set to <strong>30 03 * * *</strong> which would force all files to be moved at <strong>3:30 AM</strong> every day regardless of the rules</p>
+<p>The forceParity setting allows you to override this behavior and force all files to be moved regardless of the rules.</p>
+<p>Note that no error checking is done on the cron schedule. It must be a valid entry.</p>
+:end
+
+:mover_tune_beforescript_plug:
+> Path to a script that will be run before mover starts.  This script will always be run even if the filters don't find anything to move.
+:end
+
+:mover_tune_afterscript_plug:
+> Path to a script that will be run after mover finishes.  This script will always be run.
+:end
+
+:mover_tune_movenow_plug:
+> Select <strong>Yes</strong> to follow plugin filters, <strong>No</strong> to run original mover (ignores plugin filters) from the button.
+:end
+
+:mover_tune_movingthreshold_plug:
+<p> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive for mover to run. When this threshold is reached, the mover will start running to move data off the cache pool.</p>
+<p> <u>Note:</u> If you observe that the <strong>mover is NOT moving data when it should</strong>, try setting a <strong>higher moving threshold</strong> to increase the gap between the moving and freeing thresholds.</p>
+<p> Mover calculates the sum of the used cache pool size and file size until exceed the freeing threshold. If you have large files, this might result in not fitting within the allocated space for freeing thresholds.</p>
+:end
+
+:mover_tune_freeingthreshold_plug:
+<p> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive after the mover has completed its run. Setting this to (<strong><em> 0% </em></strong>) means that the mover will continue until all data is moved off the cache pool.</p>
+<p> <u>Note:</u> If you observe that the <strong>mover is NOT moving data when it should</strong>, try setting a <strong>lower freeing threshold</strong> to increase the gap between the moving and freeing thresholds.</p>
+<p> Mover calculates the sum of the used cache pool size and file size until exceed the freeing threshold. If you have large files, this might result in not fitting within the allocated space for freeing thresholds.</p>
+:end
+
+:mover_tune_fillupthreshold_plug:
+> Set to the amount of disk space used on the <strong><em>Secondary->Primary</em></strong> (cache:<strong>prefer</strong>) drive after the mover has completed its run. Setting this to (<strong><em>95%</em></strong>) means that the mover will continue until <strong><em>95%</em></strong> of the cache pool is filled.
+:end
+
+:mover_tune_age_plug:
+> Select if you want to move files off of the Primary (cache) based on their age - days old.
+:end
+
+:mover_tune_daysold_plug:
+> Select the number of **days old** a file has to be in order to move (Up To 1 year). Auto will move from the oldest to the most recent, until threshold is met.
+:end
+
+:mover_tune_advancedfilters_plug:
+> Show advanced filter options. Please note that these filters are active if set even if not shown.
+:end
+
+:mover_tune_ctime_plug:
+> Use <strong>CTIME</strong> <em>( creation time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
+:end
+
+:mover_tune_atime_plug:
+> Use <strong>ATIME</strong> <em>( access time )</em> instead of <strong>MTIME</strong> <em>( modification time )</em> in the find command.
+:end
+
+:mover_tune_sizef_plug:
+> Select <strong>yes</strong> if you want to move files based on their size in <strong>MB</strong>.
+:end
+
+:mover_tune_sizeinm_plug:
+> Select the minimum size a file has to be to get moved (in **Megabytes**).
+:end
+
+:mover_tune_sizefsync_plug:
+> Select <strong>yes</strong> if you want to sync files based on their size in <strong>MB</strong>. This option is only applicable when the Synchronize or Resynchronize feature is enabled.
+:end
+
+:mover_tune_sizeinmsync_plug:
+> Select the maximum size a file has to be to get synched (in **Megabytes**).
+:end
+
+:mover_tune_sparsnessf_plug:
+> Select the sparseness size. Any file with a sparseness larger will be moved.
+:end
+
+:mover_tune_sparsnessv_plug:
+> Select the sparseness size greater than that will be moved.
+:end
+
+:mover_tune_filelistv_plug:
+<p> Full path to a file that contains a list of files and folders you want ignored from being moved off the Primary (cache) pool.</p>
+<p> <strong>File List</strong> example: <strong><em>/mnt/user/Files/mover_ignore.txt</em></strong> , The contents of this file should be one entry per line.</p>
+<p> <strong>Folder</strong> example: <strong><em>/mnt/cache_ssd/Files/MyFolder</em></strong> , Do <strong>NOT</strong> put (<strong><em> * </em></strong>) or (<strong><em> / </em></strong>) at the end of the line.</p>
+<p> <strong>File</strong> example: <strong><em>/mnt/cache_ssd/Files/MyFile.txt</em></strong> .</p>
+<p> <strong>Wildcard</strong> example:</p>
+<ul>
+  <li><strong><em>/mnt/cache_ssd/Files/MyFolder/*.ext</em></strong> , Excludes all files matching the pattern recursively within that folder.</li>
+  <li><strong><em>/mnt/cache_ssd/Files/MyFolder/*MyFile*</em></strong> , Excludes all folders and files matching the pattern recursively within that folder.</li>
+</ul>
+<p> Size is not tracked for wildcard entries.</p>
+:end
+
+:mover_tune_filetypesv_plug:
+> A list of file types separated by a <strong>comma</strong>.
+:end
+
+:mover_tune_ignorehidden_plug:
+<p>Very few will use this, keep set to No.</p>
+<p>Removes any files or directories that start with a (<strong><em> . </em></strong>).</p>
+<p>Adds (<strong><em> -not -path '*/\.*' </em></strong>) to the end of the find command.</p>
+:end
+
+:mover_tune_omovercfg_plug:
+<p>Set to <strong>Yes</strong> if you want to move all files from a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share to the array if the percentage below is exceeded.</p>
+<p>This is similar to the original mover and does not apply any filters from this plug-in to the find command sent to the mover binary.</p>
+:end
+
+:mover_tune_omoverthresh_plug:
+<p>Set to the amount of disk space used on the Primary pool to initiate a move of all files in a <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) share.</p>
+<p>Filters will still run after, for any remaining pool's that do not meet this threshold.</p>
+<p>This threshold should at a minimum be <strong>5%</strong> larger than <strong><em>Only move at this threshold of used primary (cache) space</em></strong> setting above.</p>
+:end
+
+:mover_tune_enableturbo_plug:
+> Forces unRaid to switch to turbo write mode (reconstruct write) when mover is running.
+:end
+
+:mover_tune_movefilestool_plug:
+<p>This will change the tool used for moving files with <strong>plugin filters</strong>, allowing you to select between <strong>Rsync</strong> or <strong>Move</strong> Unraid's built-in file-moving utility.</p>
+<p><strong>Move</strong> - Use Unraid's built-in file-moving tool for moving, but continue to use <strong>Rsync</strong> for syncing files.</p>
+<p><strong>Rsync</strong> - Use Rsync for both moving and syncing files.</p>
+:end
+
+:mover_tune_moveemptyfolders_plug:
+> This will also move <strong>empty folders</strong> on a share, including those that are not related to the files that were moved.
+:end
+
+:mover_tune_cleanfolders_plug:
+<p><strong>Yes</strong> - Removes the parent folder <strong>only of moved</strong> files.</p>
+<p><strong>Top Folder</strong> - Removes the top-level <strong>share folder</strong> of the moved content, including <strong>all empty subfolders</strong> on the primary storage.</p>
+:end
+
+:mover_tune_cleandatasets_plug:
+> This will <strong>unmount</strong> and <strong>destroy</strong> the parent ZFS dataset on share of moved files, <strong>only if not contain</strong> child datasets within.
+:end
+
+:mover_tune_sharecalculation_plug:
+<p>Enable or disable share size calculation on the <strong><em>Primary</em></strong> storage (cache:<strong>only</strong>).</p>
+<p>This runs <strong><code>du</code></strong> on the share, which can be <strong>heavy</strong> on large XFS/Btrfs shares with many files.</p>
+:end
+
+:mover_tune_synchronizecache_plug:
+<p>This will synchronize the Primary (cached) files on both Primary and Secondary (array) so they are backed up and parity protected.</p>
+<p>Reading and modification will still occur on Primary. Sync files based on maximum size optionally can be used.</p>
+<p><u>Note:</u></p>
+<ul>
+  <li><strong>ONLY modified files</strong> since the last sync are <strong>synchronized</strong>.</li>
+  <li><strong>ONLY files</strong> on the cache pool <strong>below</strong> moving and freeing thresholds can be <strong>synchronized</strong>.</li>
+</ul>
+:end
+
+:mover_tune_advancedoptions_plug:
+> Show advanced options. Please note that these options are active if set even if not shown.
+:end
+
+:mover_tune_rebalanceshares_plug:
+<p>Moves files from shares to their Primary and/or Secondary storage if they are spread across <strong><em>Unattended Storage</em></strong> (disks/pools not assigned as a share's Primary or Secondary).</p>
+<p>May move older files from <strong><em>Primary->Secondary</em></strong> or <strong><em>Secondary->Primary</em></strong> if allowed (cache:prefer, cache:yes, cache:only) to free up space.</p>
+<p>Run-once setting will reset back to <strong>No</strong> after next run.</p>
+:end
+
+:mover_tune_resynchronizecache_plug:
+<p>This will resynchronize the Primary (cached) files on both Primary and Secondary (array) so they are backed up and parity protected.</p>
+<p>All files will be synchronized again independently of modification time.</p>
+<p>This can be a long operation. Run-once setting will reset back to <strong>No</strong> after next run.</p>
+:end
+
+:mover_tune_moveroverride_plug:
+> Select **Yes** to override the primary Mover Tuning settings for this share.
+:end
+
+:mover_tune_share_age_prefer_plug:
+> Select **Yes** to move files to the Primary (cache) based on their age (in **days**).
+:end
+
+:mover_tune_share_daysold_plug:
+> Select the number of days old a file has to be in order to move (Up To 1 year). Auto will move from the oldest to the most recent, until threshold is met.
+:end
+
+:mover_tune_share_sizef_plug:
+> Select **Yes** to move files based on their file size.
+:end
+
+:mover_tune_share_sparsnessf_plug:
+> Select **Yes** to move files based on their sparseness.
+:end
+
+:mover_tune_share_sparsnessv_plug:
+> Select the minimum sparseness a file has to be to get moved.
+:end
+
+:mover_tune_filelistf_plug:
+> Select **Yes** to skip files which have been listed in a specified text file.
+:end
+
+:mover_tune_share_filelistv_plug:
+> Specify the full path to a text file that contains the list of files the mover should skip.
+:end
+
+:mover_tune_filetypesf_plug:
+> Select **Yes** to skip specific file types in addition to those selected globally.
+:end
+
+:mover_tune_share_filetypesv_plug:
+> Specify the file types to be skipped, separated by a comma (e.g. **".txt,.mp3,.pdf"**).
+:end
+
+:mover_tune_share_ignorehidden_plug:
+> Select **Yes** to skip all hidden files and directories (starting with **"."**).
+:end
+
+:mover_tune_share_moveshare_prefer_plug:
+> Clicking the **Move Now** button will invoke the **unraid mover** specifically for this share. It will move the entire share **_Secondary->Primary_** storage space, disregarding any existing mover settings.
+:end
+
+:mover_tune_share_movingthreshold_plug:
+> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive for mover to run. When this threshold is reached, the mover will start running to move data off the cache pool.
+:end
+
+:mover_tune_share_freeingthreshold_plug:
+> Set to the amount of disk space used on the <strong><em>Primary->Secondary</em></strong> (cache:<strong>yes</strong>) drive after the mover has completed its run. Setting this to (<strong><em> 0% </em></strong>) means that the mover will continue until all data is moved off the cache pool.
+:end
+
+:mover_tune_share_age_yes_plug:
+> Select **Yes** to move files off of the Primary (cache) based on their age (in **days**).
+:end
+
+:mover_tune_share_moveshare_yes_plug:
+> Clicking the **Move Now** button will invoke the **unraid mover** specifically for this share. It will move the entire share **_Primary->Secondary_** storage space, disregarding any existing mover settings.
+:end

--- a/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/languages/en_US.txt
+++ b/source/ca.mover.tuning/usr/local/emhttp/plugins/ca.mover.tuning/languages/en_US.txt
@@ -73,7 +73,6 @@ Move files off Primary cache based on age=Move files off Primary (<em>cache</em>
 Move files off Primary cache based on sparseness=Move files off Primary (cache) based on sparseness
 Move files that are greater than this many days old=
 Move files that are greater than this sparseness=
-Move files that are greather than this sparseness=
 Move files that are larger than this size In MB=Move files that are larger than this size (In MB)
 Move files tool=
 Move files to Primary cache based on age=Move files to Primary (<em>cache</em>) based on age


### PR DESCRIPTION
Closes the plugin side of #74.

Every label, option, help block, tab title and JavaScript notice follows the Unraid display language. Translations ship with the plugin: `languages/en_US.txt` is the English master, and a `languages/<locale>.txt` next to it is used when that locale is active. Nothing goes through the Unraid language pack repos, and English users see no change.

The `Menu="Buttons"` page merges the file before the tab titles and `_(…)_` markers render, which an in-page call is too late for.

Tested with a pseudo-locale render of every page variant, and on 7.3.2 with the Chinese pack active.

**Adding a language:** copy `languages/en_US.txt` to `languages/<locale>.txt` (the folder name of the Unraid pack, e.g. `zh_CN.txt`), fill in the text after each `=`, and open a PR; it ships with the next release. The file header explains the two formats and the one rule that matters: inside a multi-line section, a line containing `=` must start with `>`, or Unraid drops the whole file.

**Keeping the master current:** when a page string changes, change its line in `languages/en_US.txt`. The left-hand side is the page text with `?{}|&~![]()/\:*^."'` and HTML tags removed, which is how Unraid's `_()` looks keys up. A missing or stale key just shows English.

The CA template can now carry `<MultiLanguage>true</MultiLanguage>`.

This also fixes the settings layout on Unraid before 7.2.1. A version check's PHP line sat directly against Markdown text, so Markdown made it part of a label and the rest of the form rendered inside that unclosed label cell. The share page had the same pattern at its start and end. PHP branch lines now stand alone, and a static check confirms every branch of both pages leaves the markup balanced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localization across Mover Tuning settings, scheduling, share options, notifications, accessibility text, and command-line guidance.
  - Added English translations for labels, descriptions, inline help, and troubleshooting information.
  - Added localized threshold warnings and range-adjustment messages while preserving existing behavior.
  - Added version-specific guidance for Unraid 7.2.1, including scheduler and mover command usage.

- **Documentation**
  - Reorganized inline help for test mode, validation, filtering, options, logging, and support links.
  - Corrected wording, punctuation, terminology, and formatting throughout the plugin’s help content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
