### PR TITLE
Test plugin build for labelled pull requests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   PLUGIN_NAME: ca.mover.tuning
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   build:
@@ -27,18 +28,35 @@ jobs:
         path: ca.mover.tuning
         persist-credentials: false
 
-    - name: Build the package with the build time as version suffix
+    - name: Version the build just above the base branch's release
+      id: version
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        set -euo pipefail
+        # Unraid orders versions with strcmp and refuses to install an older one: <release>.0<UTC build time>
+        # sorts above the current release and below whatever is released next. PR publish checks the same rule.
+        gh api "repos/$GITHUB_REPOSITORY/contents/plugins/$PLUGIN_NAME.plg?ref=$BASE_SHA" --jq .content | base64 -d > base.plg
+        release=$(grep -o '<!ENTITY version *"[^"]*"' base.plg | grep -o '"[^"]*"' | tr -d '"')
+        [[ "$release" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}[0-9a-z.]*$ ]] || { echo "::error::unexpected version '$release' on the base branch"; exit 1; }
+        version="$release.0$(date -u +%y%m%d%H%M%S)"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "version $version (release $release)"
+
+    - name: Build the package
+      env:
+        PKG_VERSION: ${{ steps.version.outputs.version }}
       run: |
         cd "$PLUGIN_NAME/source/$PLUGIN_NAME"
-        bash pkg_build.sh "$GITHUB_WORKSPACE" ".$(date -u +%H%M)"
+        bash pkg_build.sh "$GITHUB_WORKSPACE"
 
     - name: Collect the package and manifest
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
-        cfg="$PLUGIN_NAME/source/$PLUGIN_NAME/usr/local/emhttp/plugins/$PLUGIN_NAME/default.cfg"
-        version=$(sed -n 's/^version="\([^"]*\)"/\1/p' "$cfg")
         mkdir out
-        cp "$PLUGIN_NAME/archive/$PLUGIN_NAME-$version-x86_64-1.txz" "$PLUGIN_NAME/plugins/$PLUGIN_NAME.plg" out/
-        echo "$version" > out/version
+        cp "$PLUGIN_NAME/archive/$PLUGIN_NAME-$VERSION-x86_64-1.txz" "$PLUGIN_NAME/plugins/$PLUGIN_NAME.plg" out/
+        echo "$VERSION" > out/version
 
     - name: Upload the build
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -15,7 +15,6 @@ concurrency:
 
 env:
   PLUGIN_NAME: ca.mover.tuning
-  GH_TOKEN: ${{ github.token }}
 
 jobs:
   build:
@@ -31,6 +30,8 @@ jobs:
     - name: Version the build just above the base branch's release
       id: version
       env:
+        # only this step gets the token; the pull request's build script runs without it
+        GH_TOKEN: ${{ github.token }}
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: |
         set -euo pipefail

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,51 @@
+name: PR build
+
+# One test build per label: a maintainer adds the test-build label, the package is built with a read-only
+# token, "PR publish" turns it into a test plugin and takes the label off again.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'source/**'
+      - 'plugins/**'
+      - '.github/workflows/pr-build.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PLUGIN_NAME: ca.mover.tuning
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'test-build')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the pull request
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      with:
+        path: ca.mover.tuning
+
+    - name: Build the package with the build time as version suffix
+      run: |
+        cd "$PLUGIN_NAME/source/$PLUGIN_NAME"
+        bash pkg_build.sh "$GITHUB_WORKSPACE" ".$(date -u +%H%M)"
+
+    - name: Collect the package and manifest
+      run: |
+        cfg="$PLUGIN_NAME/source/$PLUGIN_NAME/usr/local/emhttp/plugins/$PLUGIN_NAME/default.cfg"
+        version=$(sed -n 's/^version="\([^"]*\)"/\1/p' "$cfg")
+        mkdir out
+        cp "$PLUGIN_NAME/archive/$PLUGIN_NAME-$version-x86_64-1.txz" "$PLUGIN_NAME/plugins/$PLUGIN_NAME.plg" out/
+        echo "$version" > out/version
+
+    - name: Upload the build
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: pr-build
+        path: out
+        retention-days: 14

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,10 +5,6 @@ name: PR build
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - 'source/**'
-      - 'plugins/**'
-      - '.github/workflows/pr-build.yml'
 
 permissions:
   contents: read
@@ -29,6 +25,7 @@ jobs:
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         path: ca.mover.tuning
+        persist-credentials: false
 
     - name: Build the package with the build time as version suffix
       run: |

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,6 +1,6 @@
 name: PR cleanup
 
-# Removes the pr-<number> test build when a pull request closes. Checks out nothing.
+# Removes the pr-<number>-<version> test builds when a pull request closes. Checks out nothing.
 on:
   pull_request_target:
     types: [closed]
@@ -16,13 +16,16 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-    - name: Remove the pull request release, its tag and the note
+    - name: Remove the pull request releases, their tags and the note
       env:
         PR: ${{ github.event.pull_request.number }}
       run: |
-        tag="pr-$PR"
-        gh release view --repo "$GITHUB_REPOSITORY" "$tag" >/dev/null 2>&1 || { echo "No test build for #$PR."; exit 0; }
-        gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag
+        set -euo pipefail
+        removed=0
+        while read -r tag; do
+          gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag; echo "removed $tag"; removed=1
+        done < <(gh api --paginate "repos/$GITHUB_REPOSITORY/releases" --jq ".[] | select(.prerelease and (.tag_name | startswith(\"pr-$PR-\"))) | .tag_name")
+        [ "$removed" = 1 ] || { echo "No test build for #$PR."; exit 0; }
         marker="<!-- pr-build -->"
         id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" | head -n 1)
         if [ -n "$id" ] && [ "$id" != "null" ]; then

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,30 @@
+name: PR cleanup
+
+# Removes the pr-<number> test build when a pull request closes. Checks out nothing.
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remove the pull request release, its tag and the note
+      env:
+        PR: ${{ github.event.pull_request.number }}
+      run: |
+        tag="pr-$PR"
+        gh release view --repo "$GITHUB_REPOSITORY" "$tag" >/dev/null 2>&1 || { echo "No test build for #$PR."; exit 0; }
+        gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag
+        marker="<!-- pr-build -->"
+        id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id")
+        if [ -n "$id" ] && [ "$id" != "null" ]; then
+          gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" -X PATCH -f body="$marker"$'\n'"The test build for this pull request has been removed." >/dev/null
+        fi

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
         gh release view --repo "$GITHUB_REPOSITORY" "$tag" >/dev/null 2>&1 || { echo "No test build for #$PR."; exit 0; }
         gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag
         marker="<!-- pr-build -->"
-        id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id")
+        id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" | head -n 1)
         if [ -n "$id" ] && [ "$id" != "null" ]; then
           gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" -X PATCH -f body="$marker"$'\n'"The test build for this pull request has been removed." >/dev/null
         fi

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -21,11 +21,14 @@ jobs:
         PR: ${{ github.event.pull_request.number }}
       run: |
         set -euo pipefail
-        removed=0
+        # listed first: a failing call inside a process substitution would read as "nothing to remove"
+        tags=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases" --jq ".[] | select(.prerelease and (.tag_name | startswith(\"pr-$PR-\"))) | .tag_name")
+        [ -n "$tags" ] || echo "No test build for #$PR."
         while read -r tag; do
-          gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag; echo "removed $tag"; removed=1
-        done < <(gh api --paginate "repos/$GITHUB_REPOSITORY/releases" --jq ".[] | select(.prerelease and (.tag_name | startswith(\"pr-$PR-\"))) | .tag_name")
-        [ "$removed" = 1 ] || { echo "No test build for #$PR."; exit 0; }
+          [ -n "$tag" ] || continue
+          gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag; echo "removed $tag"
+        done <<< "$tags"
+        # also when nothing was left: an earlier attempt may have removed the builds and failed before this
         marker="<!-- pr-build -->"
         id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" | head -n 1)
         if [ -n "$id" ] && [ "$id" != "null" ]; then

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -1,7 +1,8 @@
 name: PR publish
 
-# Runs with the repository's own code only: takes the "PR build" artifact, publishes it as the pr-<number>
-# prerelease and keeps one comment on the pull request up to date. Never checks out or runs pull request code.
+# Runs with the repository's own code only: takes the "PR build" artifact, checks it against the base branch,
+# publishes it as the pr-<number>-<version> pre-release, verifies what a server will fetch and keeps one
+# comment on the pull request current. Never checks out or runs pull request code.
 on:
   workflow_run:
     workflows: ["PR build"]
@@ -18,27 +19,30 @@ concurrency:
 
 env:
   PLUGIN_NAME: ca.mover.tuning
+  LABEL: test-build
+  MARKER: '<!-- pr-build -->'
   GH_TOKEN: ${{ github.token }}
+  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
 jobs:
   publish:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-    - name: Find the open pull request this build belongs to
+    - name: Find the labelled pull request this build belongs to
       id: pr
       env:
         HEAD: ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
-        SHA: ${{ github.event.workflow_run.head_sha }}
       run: |
-        number=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100&head=$HEAD" --jq "map(select(.head.sha == \"$SHA\")) | .[0].number")
+        set -euo pipefail
+        number=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100&head=$HEAD" --jq "map(select(.head.sha == \"$HEAD_SHA\")) | .[0].number")
         if [ -z "$number" ] || [ "$number" = "null" ]; then
-          echo "No open pull request at $HEAD $SHA, nothing to publish."
+          echo "No open pull request at $HEAD ${HEAD_SHA::7}; nothing to publish."
           exit 0
         fi
-        # the label is the maintainer's go; checked here too because this is the privileged step
-        if ! gh api "repos/$GITHUB_REPOSITORY/pulls/$number" --jq '.labels[].name' | grep -qx 'test-build'; then
-          echo "Pull request #$number has no test-build label, nothing to publish."
+        # the label is the maintainer's go; checked here too because this is the privileged job
+        if ! gh api "repos/$GITHUB_REPOSITORY/pulls/$number" --jq '.labels[].name' | grep -qx -- "$LABEL"; then
+          echo "Pull request #$number does not carry the $LABEL label; nothing to publish."
           exit 0
         fi
         echo "number=$number" >> "$GITHUB_OUTPUT"
@@ -52,73 +56,146 @@ jobs:
         github-token: ${{ github.token }}
         path: out
 
-    - name: Point the manifest at the pull request release
+    - name: Install xmllint
       if: steps.pr.outputs.number != ''
-      id: manifest
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq libxml2-utils
+
+    - name: Check the build against the base branch
+      if: steps.pr.outputs.number != ''
+      id: meta
       env:
         PR: ${{ steps.pr.outputs.number }}
       run: |
+        set -euo pipefail
+        # everything in out/ was written by the pull request's own build; the base branch's manifest is the reference
+        base=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .base.ref)
+        [[ "$base" =~ ^[A-Za-z0-9._/-]+$ ]] || { echo "::error::unexpected base branch '$base'"; exit 1; }
+        gh api "repos/$GITHUB_REPOSITORY/contents/plugins/$PLUGIN_NAME.plg?ref=$base" --jq .content | base64 -d > base.plg
+        entity() { grep -o "<!ENTITY $1 *\"[^\"]*\"" "$2" | grep -o '"[^"]*"' | tr -d '"'; }
+        release=$(entity version base.plg)
         version=$(tr -d '[:space:]' < out/version)
-        [[ "$version" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(\.[0-9]{4})?$ ]] || { echo "Unexpected version: $version"; exit 1; }
-        package="$PLUGIN_NAME-$version-x86_64-1.txz"
-        test -s "out/$package"
-        base="https://github.com/$GITHUB_REPOSITORY/releases/download/pr-$PR"
+        # the version must sort above the current release and below the next one (see PR build)
+        [[ "$version" == "$release.0"* && "${version#"$release.0"}" =~ ^[0-9]{12}$ ]] \
+          || { echo "::error::version '$version' is not '$release.0<build time>'; if the base branch released since the build, add the label again"; exit 1; }
         plg="out/$PLUGIN_NAME.plg"
-        sed -i -e "s|^<!ENTITY pluginURL .*|<!ENTITY pluginURL \"$base/$PLUGIN_NAME.plg\">|" \
-               -e "s|<URL>https://github.com/&github;/raw/&branch;/archive/&name;-&version;-x86_64-1.txz</URL>|<URL>$base/$package</URL>|" "$plg"
-        [ "$(grep -c "$base" "$plg")" = 2 ] || { echo "Manifest rewrite failed"; exit 1; }
+        package="$PLUGIN_NAME-$version-x86_64-1.txz"
+        [ -s "$plg" ] && [ -s "out/$package" ] || { echo "::error::expected $plg and out/$package in the build"; exit 1; }
+        [ "$(entity version "$plg")" = "$version" ] || { echo "::error::the manifest's version entity is not $version"; exit 1; }
         md5=$(md5sum "out/$package" | cut -d' ' -f1)
-        grep -Fq "\"$md5\"" "$plg" || { echo "Manifest md5 does not match the package"; exit 1; }
-        { echo "version=$version"; echo "package=$package"; echo "url=$base/$PLUGIN_NAME.plg"; } >> "$GITHUB_OUTPUT"
+        [ "$(entity md5 "$plg")" = "$md5" ] || { echo "::error::the manifest's md5 does not match the package"; exit 1; }
+        # pluginURL outlives the test: servers keep checking it for updates, so it must be the base branch's
+        want_url=$(xmllint --xpath 'string(/PLUGIN/@pluginURL)' base.plg)
+        got_url=$(xmllint --xpath 'string(/PLUGIN/@pluginURL)' "$plg")
+        [ -n "$want_url" ] && [ "$got_url" = "$want_url" ] || { echo "::error::manifest pluginURL '$got_url' differs from the base branch's '$want_url'"; exit 1; }
+        # only the package download moves to the pull request release
+        tag="pr-$PR-$version"
+        release_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$tag"
+        sed -i "s|<URL>https://github.com/&github;/raw/&branch;/archive/&name;-&version;-x86_64-1.txz</URL>|<URL>$release_url/$package</URL>|" "$plg"
+        [ "$(grep -cF "<URL>$release_url/$package</URL>" "$plg")" = 1 ] || { echo "::error::manifest package URL rewrite failed"; exit 1; }
+        { echo "version=$version"; echo "tag=$tag"; echo "package=$package"; echo "md5=$md5"; echo "install_url=$release_url/$PLUGIN_NAME.plg"; } >> "$GITHUB_OUTPUT"
 
-    - name: Publish the pull request release
+    - name: Publish the pre-release
       if: steps.pr.outputs.number != ''
+      id: publish
       env:
         PR: ${{ steps.pr.outputs.number }}
-        PACKAGE: ${{ steps.manifest.outputs.package }}
+        TAG: ${{ steps.meta.outputs.tag }}
+        VERSION: ${{ steps.meta.outputs.version }}
+        PACKAGE: ${{ steps.meta.outputs.package }}
+        INSTALL_URL: ${{ steps.meta.outputs.install_url }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
-        tag="pr-$PR"
-        if ! gh release view --repo "$GITHUB_REPOSITORY" "$tag" >/dev/null 2>&1; then
-          gh release create --repo "$GITHUB_REPOSITORY" "$tag" --prerelease --target "$DEFAULT_BRANCH" --title "Test build for pull request #$PR" \
-            --notes "Test build for #$PR. Not a release: replaced on every push and removed when the pull request closes."
-        fi
-        # only the current package stays on the release
-        gh release view --repo "$GITHUB_REPOSITORY" "$tag" --json assets --jq '.assets[].name' | grep '\.txz$' | grep -v -x -F "$PACKAGE" | while read -r old; do
-          gh release delete-asset --repo "$GITHUB_REPOSITORY" "$tag" "$old" --yes
-        done || true
-        gh release upload --repo "$GITHUB_REPOSITORY" "$tag" "out/$PACKAGE" "out/$PLUGIN_NAME.plg" --clobber
+        set -euo pipefail
+        notes=$(mktemp)
+        {
+          echo "Test build of pull request #$PR at ${HEAD_SHA::7}. Not a release: the next build of this pull request replaces it, closing the pull request removes it, and the next real release supersedes it on installed servers."
+          echo
+          echo "Install: Plugins > Install Plugin > paste \`$INSTALL_URL\`"
+        } > "$notes"
+        # a re-run of the same build meets its own tag; replace it (a new build always has a new version)
+        if gh release view --repo "$GITHUB_REPOSITORY" "$TAG" >/dev/null 2>&1; then gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes; fi
+        if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" >/dev/null 2>&1; then gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG"; fi
+        # a fork's head commit is not in this repository, so the tag sits on the default branch; the notes name the commit
+        gh release create --repo "$GITHUB_REPOSITORY" "$TAG" "out/$PACKAGE" "out/$PLUGIN_NAME.plg" --target "$DEFAULT_BRANCH" --prerelease \
+          --title "Test build $VERSION (pull request #$PR, ${HEAD_SHA::7})" --notes-file "$notes"
 
-    - name: Comment on the pull request
+    - name: Verify what a server will fetch
+      if: steps.pr.outputs.number != ''
+      id: verify
+      env:
+        INSTALL_URL: ${{ steps.meta.outputs.install_url }}
+        PACKAGE: ${{ steps.meta.outputs.package }}
+        WANT: ${{ steps.meta.outputs.md5 }}
+      run: |
+        set -euo pipefail
+        # Assets take a few seconds to serve after a release is created.
+        for attempt in 1 2 3 4 5 6; do
+          if curl --connect-timeout 15 --max-time 120 -fsSL -o got.plg "$INSTALL_URL" \
+             && curl --connect-timeout 15 --max-time 120 -fsSL -o got.txz "${INSTALL_URL%/*}/$PACKAGE"; then break; fi
+          [ "$attempt" -lt 6 ] || { echo "::error::assets not downloadable after $attempt attempts"; exit 1; }
+          sleep 10
+        done
+        cmp -s got.plg "out/$PLUGIN_NAME.plg" || { echo "::error::served manifest differs from the built one"; exit 1; }
+        got=$(md5sum got.txz | cut -d' ' -f1)
+        [ "$got" = "$WANT" ] || { echo "::error::served package md5 $got does not match the manifest's $WANT"; exit 1; }
+        echo "::notice::install URL: $INSTALL_URL"
+
+    - name: Remove the unverified build
+      if: failure() && steps.verify.outcome == 'failure'
+      env:
+        TAG: ${{ steps.meta.outputs.tag }}
+      run: gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes
+
+    - name: Remove older builds of this pull request
       if: steps.pr.outputs.number != ''
       env:
         PR: ${{ steps.pr.outputs.number }}
-        VERSION: ${{ steps.manifest.outputs.version }}
-        URL: ${{ steps.manifest.outputs.url }}
-        RUN: ${{ github.event.workflow_run.html_url }}
+        TAG: ${{ steps.meta.outputs.tag }}
       run: |
-        marker="<!-- pr-build -->"
-        body=$(printf '%s\n' "$marker" "Test build \`$VERSION\` for this pull request, replaced on every push ([build log]($RUN))." "" "Install from Plugins, Install Plugin, with this URL:" "" '```' "$URL" '```' "" "Reinstall the official plugin URL when done; until then the plugin updates from this pull request. Add the test-build label again for a new build.")
-        id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" | head -n 1)
-        if [ -n "$id" ] && [ "$id" != "null" ]; then
+        set -euo pipefail
+        gh api --paginate "repos/$GITHUB_REPOSITORY/releases" \
+          --jq ".[] | select(.prerelease and .tag_name != \"$TAG\" and (.tag_name | startswith(\"pr-$PR-\"))) | .tag_name" \
+          | while read -r old; do gh release delete --repo "$GITHUB_REPOSITORY" "$old" --cleanup-tag --yes; echo "removed $old"; done
+
+    - name: Update the pull request comment
+      # also on failure: a workflow_run job is not a check on the pull request, so this is where a maintainer sees it
+      if: always() && steps.pr.outputs.number != ''
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+        VERSION: ${{ steps.meta.outputs.version }}
+        INSTALL_URL: ${{ steps.meta.outputs.install_url }}
+        BUILD_LOG: ${{ github.event.workflow_run.html_url }}
+        VERIFIED: ${{ steps.verify.outcome == 'success' }}
+      run: |
+        set -euo pipefail
+        if [ "$VERIFIED" = true ]; then
+          body=$(printf '%s\n' "$MARKER" "Test build \`$VERSION\` of ${HEAD_SHA::7} ([build log]($BUILD_LOG)). Install from Plugins, Install Plugin, with this URL:" "" '```' "$INSTALL_URL" '```' "" "It installs over the current release and the next real release supersedes it. Add the \`$LABEL\` label again for a new build.")
+        else
+          body=$(printf '%s\n' "$MARKER" "The build of ${HEAD_SHA::7} was not published ([build log]($BUILD_LOG), [publish log](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)). Add the \`$LABEL\` label again to retry.")
+        fi
+        id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" \
+          --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" | head -n 1)
+        if [ -n "$id" ]; then
           gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" -X PATCH -f body="$body" >/dev/null
         else
           gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -X POST -f body="$body" >/dev/null
         fi
 
     - name: Take the label off so the next build needs a new go
-      if: steps.pr.outputs.number != ''
+      if: always() && steps.pr.outputs.number != ''
       env:
         PR: ${{ steps.pr.outputs.number }}
-      run: gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/test-build" -X DELETE >/dev/null
+      run: gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/$LABEL" -X DELETE >/dev/null
 
     - name: Undo the release if the pull request closed meanwhile
       if: steps.pr.outputs.number != ''
       env:
         PR: ${{ steps.pr.outputs.number }}
+        TAG: ${{ steps.meta.outputs.tag }}
       run: |
+        set -euo pipefail
         # PR cleanup runs on close and finds nothing when it races this job; finish the job the same way
         if [ "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .state)" != "open" ]; then
-          gh release delete --repo "$GITHUB_REPOSITORY" "pr-$PR" --yes --cleanup-tag
+          gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes
           echo "Pull request #$PR closed while publishing; the release was removed again."
         fi

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -1,0 +1,113 @@
+name: PR publish
+
+# Runs with the repository's own code only: takes the "PR build" artifact, publishes it as the pr-<number>
+# prerelease and keeps one comment on the pull request up to date. Never checks out or runs pull request code.
+on:
+  workflow_run:
+    workflows: ["PR build"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: pr-publish-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+env:
+  PLUGIN_NAME: ca.mover.tuning
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  publish:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Find the open pull request this build belongs to
+      id: pr
+      env:
+        HEAD: ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
+        SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        number=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100&head=$HEAD" --jq "map(select(.head.sha == \"$SHA\")) | .[0].number")
+        if [ -z "$number" ] || [ "$number" = "null" ]; then
+          echo "No open pull request at $HEAD $SHA, nothing to publish."
+          exit 0
+        fi
+        # the label is the maintainer's go; checked here too because this is the privileged step
+        if ! gh api "repos/$GITHUB_REPOSITORY/pulls/$number" --jq '.labels[].name' | grep -qx 'test-build'; then
+          echo "Pull request #$number has no test-build label, nothing to publish."
+          exit 0
+        fi
+        echo "number=$number" >> "$GITHUB_OUTPUT"
+
+    - name: Download the build
+      if: steps.pr.outputs.number != ''
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      with:
+        name: pr-build
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ github.token }}
+        path: out
+
+    - name: Point the manifest at the pull request release
+      if: steps.pr.outputs.number != ''
+      id: manifest
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+      run: |
+        version=$(tr -d '[:space:]' < out/version)
+        [[ "$version" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(\.[0-9]{4})?$ ]] || { echo "Unexpected version: $version"; exit 1; }
+        package="$PLUGIN_NAME-$version-x86_64-1.txz"
+        test -s "out/$package"
+        base="https://github.com/$GITHUB_REPOSITORY/releases/download/pr-$PR"
+        plg="out/$PLUGIN_NAME.plg"
+        sed -i -e "s|^<!ENTITY pluginURL .*|<!ENTITY pluginURL \"$base/$PLUGIN_NAME.plg\">|" \
+               -e "s|<URL>https://github.com/&github;/raw/&branch;/archive/&name;-&version;-x86_64-1.txz</URL>|<URL>$base/$package</URL>|" "$plg"
+        [ "$(grep -c "$base" "$plg")" = 2 ] || { echo "Manifest rewrite failed"; exit 1; }
+        md5=$(md5sum "out/$package" | cut -d' ' -f1)
+        grep -Fq "\"$md5\"" "$plg" || { echo "Manifest md5 does not match the package"; exit 1; }
+        { echo "version=$version"; echo "package=$package"; echo "url=$base/$PLUGIN_NAME.plg"; } >> "$GITHUB_OUTPUT"
+
+    - name: Publish the pull request release
+      if: steps.pr.outputs.number != ''
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+        PACKAGE: ${{ steps.manifest.outputs.package }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      run: |
+        tag="pr-$PR"
+        if ! gh release view --repo "$GITHUB_REPOSITORY" "$tag" >/dev/null 2>&1; then
+          gh release create --repo "$GITHUB_REPOSITORY" "$tag" --prerelease --target "$DEFAULT_BRANCH" --title "Test build for pull request #$PR" \
+            --notes "Test build for #$PR. Not a release: replaced on every push and removed when the pull request closes."
+        fi
+        # only the current package stays on the release
+        gh release view --repo "$GITHUB_REPOSITORY" "$tag" --json assets --jq '.assets[].name' | grep '\.txz$' | grep -v -x -F "$PACKAGE" | while read -r old; do
+          gh release delete-asset --repo "$GITHUB_REPOSITORY" "$tag" "$old" --yes
+        done || true
+        gh release upload --repo "$GITHUB_REPOSITORY" "$tag" "out/$PACKAGE" "out/$PLUGIN_NAME.plg" --clobber
+
+    - name: Comment on the pull request
+      if: steps.pr.outputs.number != ''
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+        VERSION: ${{ steps.manifest.outputs.version }}
+        URL: ${{ steps.manifest.outputs.url }}
+        RUN: ${{ github.event.workflow_run.html_url }}
+      run: |
+        marker="<!-- pr-build -->"
+        body=$(printf '%s\n' "$marker" "Test build \`$VERSION\` for this pull request, replaced on every push ([build log]($RUN))." "" "Install from Plugins, Install Plugin, with this URL:" "" '```' "$URL" '```' "" "Reinstall the official plugin URL when done; until then the plugin updates from this pull request. Add the test-build label again for a new build.")
+        id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id")
+        if [ -n "$id" ] && [ "$id" != "null" ]; then
+          gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" -X PATCH -f body="$body" >/dev/null
+        else
+          gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -X POST -f body="$body" >/dev/null
+        fi
+
+    - name: Take the label off so the next build needs a new go
+      if: steps.pr.outputs.number != ''
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+      run: gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/test-build" -X DELETE >/dev/null

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -157,6 +157,21 @@ jobs:
           --jq ".[] | select(.prerelease and .tag_name != \"$TAG\" and (.tag_name | startswith(\"pr-$PR-\"))) | .tag_name" \
           | while read -r old; do gh release delete --repo "$GITHUB_REPOSITORY" "$old" --cleanup-tag --yes; echo "removed $old"; done
 
+    - name: Undo the release if the pull request closed meanwhile
+      if: always() && steps.verify.outcome == 'success'
+      id: closed
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+        TAG: ${{ steps.meta.outputs.tag }}
+      run: |
+        set -euo pipefail
+        # PR cleanup runs on close and finds nothing when it races this job; finish the job the same way
+        if [ "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .state)" != "open" ]; then
+          gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes
+          echo "closed=true" >> "$GITHUB_OUTPUT"
+          echo "Pull request #$PR closed while publishing; the release was removed again."
+        fi
+
     - name: Update the pull request comment
       # also on failure: a workflow_run job is not a check on the pull request, so this is where a maintainer sees it
       if: always() && steps.pr.outputs.number != ''
@@ -166,9 +181,12 @@ jobs:
         INSTALL_URL: ${{ steps.meta.outputs.install_url }}
         BUILD_LOG: ${{ github.event.workflow_run.html_url }}
         VERIFIED: ${{ steps.verify.outcome == 'success' }}
+        CLOSED: ${{ steps.closed.outputs.closed == 'true' }}
       run: |
         set -euo pipefail
-        if [ "$VERIFIED" = true ]; then
+        if [ "$CLOSED" = true ]; then
+          body=$(printf '%s\n' "$MARKER" "The test build for this pull request has been removed.")
+        elif [ "$VERIFIED" = true ]; then
           body=$(printf '%s\n' "$MARKER" "Test build \`$VERSION\` of ${HEAD_SHA::7} ([build log]($BUILD_LOG)). Install from Plugins, Install Plugin, with this URL:" "" '```' "$INSTALL_URL" '```' "" "It installs over the current release and the next real release supersedes it. Add the \`$LABEL\` label again for a new build.")
         else
           body=$(printf '%s\n' "$MARKER" "The build of ${HEAD_SHA::7} was not published ([build log]($BUILD_LOG), [publish log](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)). Add the \`$LABEL\` label again to retry.")
@@ -186,16 +204,3 @@ jobs:
       env:
         PR: ${{ steps.pr.outputs.number }}
       run: gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/$LABEL" -X DELETE >/dev/null
-
-    - name: Undo the release if the pull request closed meanwhile
-      if: steps.pr.outputs.number != ''
-      env:
-        PR: ${{ steps.pr.outputs.number }}
-        TAG: ${{ steps.meta.outputs.tag }}
-      run: |
-        set -euo pipefail
-        # PR cleanup runs on close and finds nothing when it races this job; finish the job the same way
-        if [ "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .state)" != "open" ]; then
-          gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes
-          echo "Pull request #$PR closed while publishing; the release was removed again."
-        fi

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: pr-publish-${{ github.event.workflow_run.head_repository.owner.login }}-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   PLUGIN_NAME: ca.mover.tuning
@@ -99,7 +99,7 @@ jobs:
       run: |
         marker="<!-- pr-build -->"
         body=$(printf '%s\n' "$marker" "Test build \`$VERSION\` for this pull request, replaced on every push ([build log]($RUN))." "" "Install from Plugins, Install Plugin, with this URL:" "" '```' "$URL" '```' "" "Reinstall the official plugin URL when done; until then the plugin updates from this pull request. Add the test-build label again for a new build.")
-        id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id")
+        id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR/comments?per_page=100" --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" | head -n 1)
         if [ -n "$id" ] && [ "$id" != "null" ]; then
           gh api "repos/$GITHUB_REPOSITORY/issues/comments/$id" -X PATCH -f body="$body" >/dev/null
         else
@@ -111,3 +111,14 @@ jobs:
       env:
         PR: ${{ steps.pr.outputs.number }}
       run: gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/test-build" -X DELETE >/dev/null
+
+    - name: Undo the release if the pull request closed meanwhile
+      if: steps.pr.outputs.number != ''
+      env:
+        PR: ${{ steps.pr.outputs.number }}
+      run: |
+        # PR cleanup runs on close and finds nothing when it races this job; finish the job the same way
+        if [ "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .state)" != "open" ]; then
+          gh release delete --repo "$GITHUB_REPOSITORY" "pr-$PR" --yes --cleanup-tag
+          echo "Pull request #$PR closed while publishing; the release was removed again."
+        fi

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -35,7 +35,9 @@ jobs:
         HEAD: ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
       run: |
         set -euo pipefail
-        number=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100&head=$HEAD" --jq "map(select(.head.sha == \"$HEAD_SHA\")) | .[0].number")
+        # gh encodes the fields; a branch name may hold & # + and would split a hand-built query
+        number=$(gh api -X GET "repos/$GITHUB_REPOSITORY/pulls" -f state=open -f per_page=100 -f head="$HEAD" \
+          --jq "map(select(.head.sha == \"$HEAD_SHA\")) | .[0].number")
         if [ -z "$number" ] || [ "$number" = "null" ]; then
           echo "No open pull request at $HEAD ${HEAD_SHA::7}; nothing to publish."
           exit 0
@@ -80,18 +82,21 @@ jobs:
         plg="out/$PLUGIN_NAME.plg"
         package="$PLUGIN_NAME-$version-x86_64-1.txz"
         [ -s "$plg" ] && [ -s "out/$package" ] || { echo "::error::expected $plg and out/$package in the build"; exit 1; }
-        [ "$(entity version "$plg")" = "$version" ] || { echo "::error::the manifest's version entity is not $version"; exit 1; }
+        # the built manifest is read parsed, the way Unraid reads it, never as text: a comment can hold anything
+        xpath() { xmllint --xpath "$1" "$plg"; }
+        [ "$(xpath 'string(/PLUGIN/@version)')" = "$version" ] || { echo "::error::the manifest's version is not $version"; exit 1; }
         md5=$(md5sum "out/$package" | cut -d' ' -f1)
-        [ "$(entity md5 "$plg")" = "$md5" ] || { echo "::error::the manifest's md5 does not match the package"; exit 1; }
+        [ "$(xpath 'string(/PLUGIN/FILE[URL]/MD5)')" = "$md5" ] || { echo "::error::the manifest's package MD5 is not $md5"; exit 1; }
         # pluginURL outlives the test: servers keep checking it for updates, so it must be the base branch's
         want_url=$(xmllint --xpath 'string(/PLUGIN/@pluginURL)' base.plg)
-        got_url=$(xmllint --xpath 'string(/PLUGIN/@pluginURL)' "$plg")
+        got_url=$(xpath 'string(/PLUGIN/@pluginURL)')
         [ -n "$want_url" ] && [ "$got_url" = "$want_url" ] || { echo "::error::manifest pluginURL '$got_url' differs from the base branch's '$want_url'"; exit 1; }
-        # only the package download moves to the pull request release
+        # only the package download moves to the pull request release; after that it must be the manifest's one download
         tag="pr-$PR-$version"
         release_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$tag"
         sed -i "s|<URL>https://github.com/&github;/raw/&branch;/archive/&name;-&version;-x86_64-1.txz</URL>|<URL>$release_url/$package</URL>|" "$plg"
-        [ "$(grep -cF "<URL>$release_url/$package</URL>" "$plg")" = 1 ] || { echo "::error::manifest package URL rewrite failed"; exit 1; }
+        [ "$(xpath 'count(/PLUGIN/FILE/URL)')" = 1 ] && [ "$(xpath 'string(/PLUGIN/FILE/URL)')" = "$release_url/$package" ] \
+          || { echo "::error::the manifest must have one download, $release_url/$package"; exit 1; }
         { echo "version=$version"; echo "tag=$tag"; echo "package=$package"; echo "md5=$md5"; echo "install_url=$release_url/$PLUGIN_NAME.plg"; } >> "$GITHUB_OUTPUT"
 
     - name: Publish the pre-release
@@ -112,12 +117,15 @@ jobs:
           echo
           echo "Install: Plugins > Install Plugin > paste \`$INSTALL_URL\`"
         } > "$notes"
-        # a re-run of the same build meets its own tag; replace it (a new build always has a new version)
-        if gh release view --repo "$GITHUB_REPOSITORY" "$TAG" >/dev/null 2>&1; then gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes; fi
-        if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" >/dev/null 2>&1; then gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG"; fi
-        # a fork's head commit is not in this repository, so the tag sits on the default branch; the notes name the commit
-        gh release create --repo "$GITHUB_REPOSITORY" "$TAG" "out/$PACKAGE" "out/$PLUGIN_NAME.plg" --target "$DEFAULT_BRANCH" --prerelease \
-          --title "Test build $VERSION (pull request #$PR, ${HEAD_SHA::7})" --notes-file "$notes"
+        # a re-run of this build meets its own release, the same bytes and maybe already announced: keep it, verify it
+        if gh release view --repo "$GITHUB_REPOSITORY" "$TAG" >/dev/null 2>&1; then
+          echo "$TAG exists already (a re-run of this build); verifying it instead of publishing it again."
+        else
+          # a fork's head commit is not in this repository, so the tag sits on the default branch; the notes name the commit
+          gh release create --repo "$GITHUB_REPOSITORY" "$TAG" "out/$PACKAGE" "out/$PLUGIN_NAME.plg" --target "$DEFAULT_BRANCH" --prerelease \
+            --title "Test build $VERSION (pull request #$PR, ${HEAD_SHA::7})" --notes-file "$notes"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Verify what a server will fetch
       if: steps.pr.outputs.number != ''
@@ -141,7 +149,7 @@ jobs:
         echo "::notice::install URL: $INSTALL_URL"
 
     - name: Remove the unverified build
-      if: failure() && steps.verify.outcome == 'failure'
+      if: failure() && steps.verify.outcome == 'failure' && steps.publish.outputs.created == 'true'
       env:
         TAG: ${{ steps.meta.outputs.tag }}
       run: gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes

--- a/source/ca.mover.tuning/pkg_build.sh
+++ b/source/ca.mover.tuning/pkg_build.sh
@@ -10,6 +10,8 @@ plugin=$(basename "${DIR}")
 archive="$(dirname "$(dirname "${DIR}")")/archive"
 # $2 is argument addition to date (a,b,c)
 version=$(date +"%Y.%m.%d")${2:-}
+# a test build passes its own version (.github/workflows/pr-build.yml)
+version=${PKG_VERSION:-$version}
 # $1 Path to the plugin directory
 config_file="$1/$plugin/plugins/$plugin.plg"
 readme_file="$1/$plugin/README.md"


### PR DESCRIPTION
One test build per label. Add the `test-build` label to a pull request when it is worth trying: PR build packages it with a read-only token, PR publish checks the build against the base branch, publishes it as a `pr-<number>-<version>` prerelease, verifies what a server will fetch, posts the install URL in one comment and takes the label off again; PR cleanup removes the builds when the pull request closes. Nothing runs without the label. Create a label named `test-build` once under Issues, Labels.

The version is the current release plus `.0` and the build time (`2026.09.07.0260910132258`), so it installs over the current release and the next real release supersedes it; `pkg_build.sh` takes it through `PKG_VERSION`. pluginURL stays on master, only the package download points at the release. The publisher refuses a build whose version, md5 or pluginURL does not match the base branch.

Tried on a fork: label, build, publish, replace on the next label, builds with a tampered version and pluginURL rejected, cleanup on close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated preview package builds for pull requests marked for testing.
  * Published test builds are available as versioned prereleases with downloadable plugin packages and version details.
  * Pull requests display or update a comment linking to the current test build.
  * Builds validate package metadata, version compatibility, package presence, and checksums before publication.
  * Re-running a build preserves and verifies its existing preview release.

* **Chores**
  * Test-build labels are removed after publication.
  * Preview releases and related pull request comments are automatically cleaned up when a pull request closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
