### PR TITLE
Update actions/checkout and actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         path: ca.mover.tuning
 
@@ -78,13 +78,13 @@ jobs:
           '{release_tag: $tag, release_name: $name, new_release: $new}' > release_info.json
 
     - name: Upload built package artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: mover-tuning-package
         path: ca.mover.tuning/archive/${{ steps.validate.outputs.package }}
 
     - name: Upload release info
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: release_info
         path: release_info.json


### PR DESCRIPTION
Upgrade the GitHub Actions dependencies for checkout and artifact upload to the latest version for improved performance and security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and release automation used to check out source code and upload build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->