### PR TITLE
Treat a label or release that is already gone as done

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -26,7 +26,10 @@ jobs:
         [ -n "$tags" ] || echo "No test build for #$PR."
         while read -r tag; do
           [ -n "$tag" ] || continue
-          gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag; echo "removed $tag"
+          # a publish run that saw the close may have removed it already: "release not found" is that outcome
+          out=$(gh release delete --repo "$GITHUB_REPOSITORY" "$tag" --yes --cleanup-tag 2>&1) \
+            || [[ "$out" == *"release not found"* ]] || { echo "$out" >&2; exit 1; }
+          echo "removed $tag"
         done <<< "$tags"
         # also when nothing was left: an earlier attempt may have removed the builds and failed before this
         marker="<!-- pr-build -->"

--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -152,7 +152,10 @@ jobs:
       if: failure() && steps.verify.outcome == 'failure' && steps.publish.outputs.created == 'true'
       env:
         TAG: ${{ steps.meta.outputs.tag }}
-      run: gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes
+      run: |
+        # PR cleanup may have removed it already: "release not found" is that outcome, anything else is not
+        out=$(gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes 2>&1) \
+          || [[ "$out" == *"release not found"* ]] || { echo "$out" >&2; exit 1; }
 
     - name: Remove older builds of this pull request
       if: steps.pr.outputs.number != ''
@@ -163,7 +166,11 @@ jobs:
         set -euo pipefail
         gh api --paginate "repos/$GITHUB_REPOSITORY/releases" \
           --jq ".[] | select(.prerelease and .tag_name != \"$TAG\" and (.tag_name | startswith(\"pr-$PR-\"))) | .tag_name" \
-          | while read -r old; do gh release delete --repo "$GITHUB_REPOSITORY" "$old" --cleanup-tag --yes; echo "removed $old"; done
+          | while read -r old; do
+              out=$(gh release delete --repo "$GITHUB_REPOSITORY" "$old" --cleanup-tag --yes 2>&1) \
+                || [[ "$out" == *"release not found"* ]] || { echo "$out" >&2; exit 1; }
+              echo "removed $old"
+            done
 
     - name: Undo the release if the pull request closed meanwhile
       if: always() && steps.verify.outcome == 'success'
@@ -173,9 +180,11 @@ jobs:
         TAG: ${{ steps.meta.outputs.tag }}
       run: |
         set -euo pipefail
-        # PR cleanup runs on close and finds nothing when it races this job; finish the job the same way
+        # PR cleanup also runs on close; whichever gets there first removes the build, so "release not found"
+        # here means cleanup did, and the build is gone either way
         if [ "$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .state)" != "open" ]; then
-          gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes
+          out=$(gh release delete --repo "$GITHUB_REPOSITORY" "$TAG" --cleanup-tag --yes 2>&1) \
+            || [[ "$out" == *"release not found"* ]] || { echo "$out" >&2; exit 1; }
           echo "closed=true" >> "$GITHUB_OUTPUT"
           echo "Pull request #$PR closed while publishing; the release was removed again."
         fi
@@ -211,4 +220,9 @@ jobs:
       if: always() && steps.pr.outputs.number != ''
       env:
         PR: ${{ steps.pr.outputs.number }}
-      run: gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/$LABEL" -X DELETE >/dev/null
+      run: |
+        # someone may have taken it off meanwhile: that 404 is the outcome wanted, any other error is not
+        if ! err=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels/$LABEL" -X DELETE 2>&1 >/dev/null); then
+          [[ "$err" == *"(HTTP 404)"* ]] || { echo "$err" >&2; exit 1; }
+          echo "The $LABEL label was already off."
+        fi


### PR DESCRIPTION
Follow-up to #196, parked as a draft.

Two races in the test-build workflows. Taking the label off failed the run with a 404 when someone had already removed it. And when a pull request closes while its build publishes, PR cleanup and PR publish can both delete the same release, so the second one hits "release not found": cleanup then stopped before updating the note, and publish failed before recording the close, leaving the install URL of the deleted build in the comment.

Both now count "already gone" as done; any other error still fails the run. Tested by running the changed steps against a stub gh, before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request cleanup reliability when releases or labels have already been removed by another process.
  * Prevented expected “not found” cleanup conditions from causing workflow failures.
  * Preserved failure reporting for unexpected cleanup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->